### PR TITLE
Change default parent authorization from :read to :modify

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -82,7 +82,7 @@ module CanCan
     end
 
     def authorization_action
-      parent? ? :read : @params[:action].to_sym
+      parent? ? :modify : @params[:action].to_sym
     end
 
     def id_param


### PR DESCRIPTION
In most scenarios a user shouldn't be able to modify the children of something that he can see.  For example one user shouldn't be able to modify any nested resource of another user unless he can modify that user.

The best solution would be to make the parent authorization action configurable
