### PR TITLE
Should not allow to 'can?' only raw sql condition is present

### DIFF
--- a/lib/cancan/can_definition.rb
+++ b/lib/cancan/can_definition.rb
@@ -55,6 +55,10 @@ module CanCan
     def only_block?
       conditions_empty? && !@block.nil?
     end
+    
+    def only_raw_sql?
+      @block.nil? && !conditions_empty? && !@conditions.kind_of?(Hash)
+    end
 
     def conditions_empty?
       @conditions == {} || @conditions.nil?

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -317,6 +317,13 @@ describe CanCan::Ability do
     end
     @ability.should have_block(:read, :foo)
   end
+  
+  it "should know when raw sql is used in conditions" do
+    @ability.can :read, :foo
+    @ability.should_not have_raw_sql(:read, :foo)
+    @ability.can :read, :foo, 'false'
+    @ability.should have_raw_sql(:read, :foo)
+  end
 
   it "should raise access denied exception with default message if not specified" do
     begin

--- a/spec/cancan/active_record_additions_spec.rb
+++ b/spec/cancan/active_record_additions_spec.rb
@@ -56,4 +56,18 @@ describe CanCan::ActiveRecordAdditions do
     stub(@model_class).scoped{|*args| args.inspect}
     @model_class.accessible_by(@ability).should == :found_records
   end
+  
+  it "should not allow to fetch records when ability with just block present" do
+    @ability.can :read, @model_class do false end
+    lambda {
+      @model_class.accessible_by(@ability)
+    }.should raise_error(CanCan::Error)
+  end
+  
+  it "should not allow to check ability on object when nonhash sql ability definition without block present" do
+    @ability.can :read, @model_class, ['bar = ?', 1]
+    lambda {
+      @ability.can? :read, @model_class.new
+    }.should raise_error(CanCan::Error)
+  end
 end


### PR DESCRIPTION
It seems that people could try to define raw sql condition without specifiyng block.
It would lead to mistakenly evaluating this condition as satisfying.

This patch is complementing to raising error on `accessible_by` when only block is defined.
