### PR TITLE
Execute block in can definition if no arguments given

### DIFF
--- a/lib/cancan/can_definition.rb
+++ b/lib/cancan/can_definition.rb
@@ -35,6 +35,8 @@ module CanCan
         nested_subject_matches_conditions?(subject)
       elsif @conditions.kind_of?(Hash) && !subject_class?(subject)
         matches_conditions_hash?(subject)
+      elsif @block && subject_class?(subject) && conditions_empty? && @block.arity <= 0
+        @block.call
       else
         # Don't stop at "cannot" definitions when there are conditions.
         @conditions.empty? ? true : @base_behavior

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -64,6 +64,16 @@ describe CanCan::Ability do
     @block_called.should be_false
   end
 
+  it "should call block when class is passed and block has no arguments" do
+    @block_called = false
+    @ability.can :create, Integer do
+      @block_called = true
+      false
+    end
+    @ability.can?(:create, Integer).should be_false
+    @block_called.should be_true
+  end
+
   it "should pass only object for global manage actions" do
     @ability.can :manage, String do |object|
       object.should == "foo"


### PR DESCRIPTION
Hi!

I've added a condition in which the block of the can definition will be executed, but only if no arguments are used in the block.

I wanted to do some more complicated logic, that would be awkward in SQL or that the logic is not related with the objects and classes used (like a separate business rule).

Example:

```
can :create, Project do
  user.projects.count < user.account.project_limit
end
```
