### PR TITLE
Fix for odd behaviour when cache_classes = false

### DIFF
--- a/lib/cancan/can_definition.rb
+++ b/lib/cancan/can_definition.rb
@@ -97,7 +97,7 @@ module CanCan
     end
 
     def matches_subject_class?(subject)
-      @subjects.any? { |sub| sub.kind_of?(Module) && (subject.kind_of?(sub) || subject.kind_of?(Module) && subject.ancestors.include?(sub)) }
+      @subjects.any? { |sub| sub.kind_of?(Module) && (subject.kind_of?(sub) || subject.class.to_s == sub.to_s || subject.kind_of?(Module) && subject.ancestors.include?(sub)) }
     end
 
     def matches_conditions_hash?(subject, conditions = @conditions)


### PR DESCRIPTION
Hi Ryan,

I ran into an issue that i've finally traced down when loading objects through associations and then trying to compare them with the classes being set int he Ability model.  This affects nested resources authorization.  I've given a detailed example in my commit message 9c46c5a6a44e4cd3857429efca635d436ff8ad62.  Again, this only seems to be an intermittent issue in development when cache_classes = false.  Here is a quick example from my commit message:

```
@photo = User.photos.first
@same_photo = Photo.find @photo.id

result = @photo.kind_of?(Photo) # result is intermittently true/false 
result = @photo == @same_photo # again, these are not always equal ... very odd.
```

Cheers,
Michael.
