### PR TITLE
Make conditions for associations with a table name distinct from the association name work correctly.

### DIFF
--- a/cancan.gemspec
+++ b/cancan.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rails', '~> 3.0.0'
   s.add_development_dependency 'rr', '~> 0.10.11' # 1.0.0 has respond_to? issues: http://github.com/btakita/rr/issues/issue/43
   s.add_development_dependency 'supermodel', '~> 0.1.4'
+  s.add_development_dependency 'with_model'
+  s.add_development_dependency 'sqlite3-ruby'
 
   s.add_development_dependency 'mongoid', '~> 2.0.0.beta.19'
   s.add_development_dependency 'bson_ext', '~> 1.1'

--- a/lib/cancan/query.rb
+++ b/lib/cancan/query.rb
@@ -26,10 +26,10 @@ module CanCan
     def conditions
       if @rules.size == 1 && @rules.first.base_behavior
         # Return the conditions directly if there's just one definition
-        @rules.first.tableized_conditions.dup
+        @rules.first.tableized_conditions(@sanitizer).dup
       else
         @rules.reverse.inject(false_sql) do |sql, rule|
-          merge_conditions(sql, rule.tableized_conditions.dup, rule.base_behavior)
+          merge_conditions(sql, rule.tableized_conditions(@sanitizer).dup, rule.base_behavior)
         end
       end
     end

--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -41,12 +41,12 @@ module CanCan
       end
     end
 
-    def tableized_conditions(conditions = @conditions)
+    def tableized_conditions(active_record_subject, conditions = @conditions)
       return conditions unless conditions.kind_of? Hash
       conditions.inject({}) do |result_hash, (name, value)|
         if value.kind_of? Hash
-          name = name.to_s.tableize.to_sym
-          value = tableized_conditions(value)
+          name = active_record_subject.reflect_on_association(name).table_name
+          value = tableized_conditions(active_record_subject, value)
         end
         result_hash[name] = value
         result_hash

--- a/spec/cancan/rule_spec.rb
+++ b/spec/cancan/rule_spec.rb
@@ -2,56 +2,84 @@ require "spec_helper"
 
 # Most of Rule functionality is tested in Ability specs
 describe CanCan::Rule do
-  before(:each) do
-    @conditions = {}
-    @rule = CanCan::Rule.new(true, :read, Integer, @conditions, nil)
+  describe "#associations_hash" do
+    before(:each) do
+      @rules = {}
+      @rule = CanCan::Rule.new(true, :read, Integer, @rules, nil)
+    end
+
+    it "should return no association joins if none exist" do
+      @rule.associations_hash.should == {}
+    end
+
+    it "should return no association for joins if just attributes" do
+      @rules[:foo] = :bar
+      @rule.associations_hash.should == {}
+    end
+
+    it "should return single association for joins" do
+      @rules[:foo] = {:bar => 1}
+      @rule.associations_hash.should == {:foo => {}}
+    end
+
+    it "should return multiple associations for joins" do
+      @rules[:foo] = {:bar => 1}
+      @rules[:test] = {1 => 2}
+      @rule.associations_hash.should == {:foo => {}, :test => {}}
+    end
+
+    it "should return nested associations for joins" do
+      @rules[:foo] = {:bar => {1 => 2}}
+      @rule.associations_hash.should == {:foo => {:bar => {}}}
+    end
+
+    it "should return no association joins if conditions is nil" do
+      can = CanCan::Rule.new(true, :read, Integer, nil, nil)
+      can.associations_hash.should == {}
+    end
   end
 
-  it "should return no association joins if none exist" do
-    @rule.associations_hash.should == {}
-  end
+  describe "#tableized_conditions" do
+    with_model :landlord do
+      table { |t| t.string :name }
+      model do
+        has_many :properties
+        has_many :units, :through => :properties
+      end
+    end
 
-  it "should return no association for joins if just attributes" do
-    @conditions[:foo] = :bar
-    @rule.associations_hash.should == {}
-  end
+    with_model :unit do
+      table do |t|
+        t.belongs_to :property
+        t.integer :room_count
+      end
+      model { belongs_to :property }
+    end
 
-  it "should return single association for joins" do
-    @conditions[:foo] = {:bar => 1}
-    @rule.associations_hash.should == {:foo => {}}
-  end
+    with_model :property do
+      table do |t|
+        t.belongs_to :landlord
+      end
+      model do
+        has_many :units
+        belongs_to :landlord
+      end
+    end
 
-  it "should return multiple associations for joins" do
-    @conditions[:foo] = {:bar => 1}
-    @conditions[:test] = {1 => 2}
-    @rule.associations_hash.should == {:foo => {}, :test => {}}
-  end
+    it "should return table names in conditions for association joins" do
+      @rules = {}
+      @rule = CanCan::Rule.new(true, :read, Property, @rules, nil)
+      @rules[:units] = {:room_count => 1}
+      @rules[:name] = 1
+      @rule.tableized_conditions(Property).should == {unit.table_name => {:room_count => 1}, :name => 1}
+    end
 
-  it "should return nested associations for joins" do
-    @conditions[:foo] = {:bar => {1 => 2}}
-    @rule.associations_hash.should == {:foo => {:bar => {}}}
-  end
-
-  it "should tableize correctly for absurdly complex permissions" do
-    @conditions[:unit] = {:property=>{:landlord=>{:weasle_id=>560}}}
-    @conditions[:test] = 1
-    @rule.tableized_conditions.should == {:units => {:properties => {:landlords=>{:weasle_id=>560}}}, :test => 1}
-  end
-
-  it "should tableize correctly for complex permissions" do
-    @conditions[:unit] = {:property=>{:landlord_id=>560}}
-    @conditions[:test] = 1
-    @rule.tableized_conditions.should == {:units => {:properties => {:landlord_id=>560}}, :test => 1}
-  end
-
-  it "should return table names in conditions for association joins" do
-    @conditions[:foo] = {:bar => 1}
-    @conditions[:test] = 1
-    @rule.tableized_conditions.should == {:foos => {:bar => 1}, :test => 1}
-  end
-
-  it "should return no association joins if conditions is nil" do
-    rule = CanCan::Rule.new(true, :read, Integer, nil, nil)
-    rule.associations_hash.should == {}
+    it "should tableize correctly for complex permissions" do
+      @rules = {}
+      @rule = CanCan::Rule.new(true, :read, Landlord, @rules, nil)
+      @rules[:properties] = {:units=>{:room_count=>2}}
+      @rules[:name] = "Weasel"
+      @rule.tableized_conditions(Landlord).should == {property.table_name => {unit.table_name => {:room_count=>2}}, :name => "Weasel"}
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require 'supermodel' # shouldn't Bundler do this already?
 require 'active_support/all'
 require 'matchers'
 require 'cancan/matchers'
+require 'active_record'
+require 'with_model'
 
 RSpec.configure do |config|
   config.mock_with :rr
@@ -12,7 +14,10 @@ RSpec.configure do |config|
     Project.delete_all
     Category.delete_all
   end
+  config.extend WithModel
 end
+
+ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => ":memory:")
 
 class Ability
   include CanCan::Ability


### PR DESCRIPTION
Updating Rule#tableize_conditions to require a subject to be passed.
This makes conditions for associations with a table name distinct from the association name work correctly.
