### PR TITLE
Add `accessible_by` class method to Mongoid documents

### DIFF
--- a/lib/cancan/model_adapters/mongoid_adapter.rb
+++ b/lib/cancan/model_adapters/mongoid_adapter.rb
@@ -51,3 +51,8 @@ module CanCan
     alias_method :matches_conditions_hash?, :matches_conditions_hash_with_mongoid_subject?
   end
 end
+
+# simplest way to add `accessible_by` to all Mongoid Documents
+module Mongoid::Document::ClassMethods
+  include CanCan::ModelAdditions::ClassMethods
+end

--- a/spec/cancan/model_adapters/mongoid_adapter_spec.rb
+++ b/spec/cancan/model_adapters/mongoid_adapter_spec.rb
@@ -3,14 +3,12 @@ if ENV["MODEL_ADAPTER"] == "mongoid"
 
   class MongoidCategory
     include Mongoid::Document
-    include CanCan::ModelAdditions
 
     references_many :mongoid_projects
   end
 
   class MongoidProject
     include Mongoid::Document
-    include CanCan::ModelAdditions
 
     referenced_in :mongoid_category
 


### PR DESCRIPTION
Thanks for the great work on the different model adapters. I made a couple of small updates so that all Mongoid documents would automatically include the `accessible_by` method without using the ugly (and no-longer-documented) `Mongoid::Components` hack.

Happy 2011!
