### PR TITLE
Pass action to accessible by

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -77,7 +77,7 @@ module CanCan
     end
 
     def load_collection
-      resource_base.accessible_by(current_ability)
+      resource_base.accessible_by(current_ability, authorization_action)
     end
 
     def build_resource


### PR DESCRIPTION
This example `can` rule had no effect on my index action:

```
  can [:read,:index], Distributor, condition do |d|
    condition = ['lft >= ? AND rgt <= ?', distributor.lft, distributor.rgt]
    d.lft >= distributor.lft and d.rgt <= distributor.rgt
  end
```

I've tested in console and the correct sql was returned only when passing action name to accessible_by. This patch fixed load_resource for me.
