### PR TITLE
Make cancan rules play nice with Hash-like subjects

### DIFF
--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -21,7 +21,7 @@ module CanCan
 
     # Matches both the subject and action, not necessarily the conditions
     def relevant?(action, subject)
-      subject = subject.values.first if subject.kind_of? Hash
+      subject = subject.values.first if subject.class == Hash
       @match_all || (matches_action?(action) && matches_subject?(subject))
     end
 
@@ -31,7 +31,7 @@ module CanCan
         call_block_with_all(action, subject, extra_args)
       elsif @block && !subject_class?(subject)
         @block.call(subject, *extra_args)
-      elsif @conditions.kind_of?(Hash) && subject.kind_of?(Hash)
+      elsif @conditions.kind_of?(Hash) && subject.class == Hash
         nested_subject_matches_conditions?(subject)
       elsif @conditions.kind_of?(Hash) && !subject_class?(subject)
         matches_conditions_hash?(subject)

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -290,6 +290,12 @@ describe CanCan::Ability do
     @ability.can?(:read, "foobar" => Range).should be_false
     @ability.can?(:read, 123 => Range).should be_true
   end
+  
+  it "should allow to check ability on Hash-like object" do
+    class Container < Hash; end
+    @ability.can :read, Container
+    @ability.can?(:read, Container.new).should be_true
+  end
 
   it "should have initial attributes based on hash conditions of 'new' action" do
     @ability.can :manage, Range, :foo => "foo", :hash => {:skip => "hashes"}


### PR DESCRIPTION
This commit fixes an issue when a subclass of Hash is given as the subject. e.g.

```
class Container < Hash
end

can :read, Container

mycontainer = Container.new(:key => "value")
can? :read, mycontainer
```
