### PR TITLE
Deeply nested resources fail to load when inherited_resources is present

### DIFF
--- a/lib/cancan/inherited_resource.rb
+++ b/lib/cancan/inherited_resource.rb
@@ -3,7 +3,8 @@ module CanCan
   class InheritedResource < ControllerResource # :nodoc:
     def load_resource_instance
       if parent?
-        @controller.send :parent
+        @controller.send :association_chain
+        @controller.instance_variable_get("@#{instance_name}")
       elsif new_actions.include? @params[:action].to_sym
         @controller.send :build_resource
       else


### PR DESCRIPTION
Unfortunately I'm too noob to provide a spec, but here's a typical failing scenario:

```
class TaskController < ApplicationController

  inherit_resources
  nested_belongs_to :team, :project
  actions :index

  load_and_authorize_resource :team
  load_and_authorize_resource :project, :through => :team
  load_and_authorize_resource :task, :through => :project

  [...]

end
```

In this case `@team` will be equal to `@project`, as `inherited_resources`'s `parent` method always returns the last parent in the chain.
