### PR TITLE
Use all instead of where

### DIFF
--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -55,8 +55,8 @@ module CanCan
       end
 
       def database_records
-        if @model_class.respond_to?(:where) && @model_class.respond_to?(:joins)
-          @model_class.where(conditions).joins(joins)
+        if @model_class.respond_to?(:all) and conditions.empty? and joins.nil?
+          @model_class.all
         else
           @model_class.scoped(:conditions => conditions, :joins => joins)
         end


### PR DESCRIPTION
This patch will allow to use default scaffolded specs without unnecessary modification. Note that calling scope and where is equivalent ...
