### PR TITLE
Inherited resources collection fix

### DIFF
--- a/lib/cancan/inherited_resource.rb
+++ b/lib/cancan/inherited_resource.rb
@@ -12,7 +12,7 @@ module CanCan
     end
 
     def resource_base
-      @controller.send :end_of_association_chain
+      @controller.send :collection
     end
   end
 end

--- a/spec/cancan/inherited_resource_spec.rb
+++ b/spec/cancan/inherited_resource_spec.rb
@@ -32,10 +32,10 @@ describe CanCan::InheritedResource do
     @controller.instance_variable_get(:@project).should == :project_resource
   end
 
-  it "index should load through @controller.end_of_association_chain" do
+  it "index should load through @controller.collection" do
     @params[:action] = "index"
     stub(Project).accessible_by(@ability, :index) { :projects }
-    stub(@controller).end_of_association_chain { Project }
+    stub(@controller).collection { Project }
     CanCan::InheritedResource.new(@controller).load_resource
     @controller.instance_variable_get(:@projects).should == :projects
   end


### PR DESCRIPTION
Use collection instead of end_of_association_chain to properly integrate with controllers using inherited_resources. See issue #274.
