### PR TITLE
Fixes inherited_resources collection authorization

### DIFF
--- a/lib/cancan/inherited_resource.rb
+++ b/lib/cancan/inherited_resource.rb
@@ -13,7 +13,7 @@ module CanCan
     end
 
     def resource_base
-      @controller.send :collection
+      @controller.send :end_of_association_chain
     end
   end
 end

--- a/spec/cancan/inherited_resource_spec.rb
+++ b/spec/cancan/inherited_resource_spec.rb
@@ -32,10 +32,10 @@ describe CanCan::InheritedResource do
     @controller.instance_variable_get(:@project).should == :project_resource
   end
 
-  it "index should load through @controller.collection" do
+  it "index should load through @controller.end_of_association_chain" do
     @params[:action] = "index"
     stub(Project).accessible_by(@ability, :index) { :projects }
-    stub(@controller).collection { Project }
+    stub(@controller).end_of_association_chain { Project }
     CanCan::InheritedResource.new(@controller).load_resource
     @controller.instance_variable_get(:@projects).should == :projects
   end


### PR DESCRIPTION
This reverts e3eab13b860ad6e21d7d

I don't know what was the idea of that, but it turned out REAL bad.

`collection` sets the collection instance variable. `resource_base` is used all over CanCan. It's also used inside `load_collection?` which is checked before `load_collection` is called. That means we actually set the collection instance variable through inherited_resources (without any authorization whatsoever) before trying to load it through CanCan using  accessible_by`.

```
1. def load_resource
2.  unless skip?(:load)
3.    if load_instance?
4.      self.resource_instance ||= load_resource_instance
5.    elsif load_collection?
6.      self.collection_instance ||= load_collection
7.    end
8.  end
9. end
```

`collection_instance` is set on line 5 instead of line 6.
