### PR TITLE
Placing conditions on optionally associated objects raises exceptions at rule match time

### DIFF
--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -109,7 +109,7 @@ module CanCan
                 if attribute.kind_of? Array
                   attribute.any? { |element| matches_conditions_hash? element, value }
                 else
-                  matches_conditions_hash? attribute, value
+                  !attribute.nil? && matches_conditions_hash?(attribute, value)
                 end
               elsif value.kind_of?(Array) || value.kind_of?(Range)
                 value.include? attribute

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -249,6 +249,13 @@ describe CanCan::Ability do
     @ability.can?(:read, 1..5).should be_true
     @ability.can?(:read, 4..6).should be_false
   end
+  
+  it "should not match subjects return nil for methods that must match nested a nested conditions hash" do
+    mock(object_with_foo = Object.new).foo { :bar }
+    @ability.can :read, Array, :first => { :foo => :bar }
+    @ability.can?(:read, [object_with_foo]).should be_true
+    @ability.can?(:read, []).should be_false
+  end
 
   it "should not stop at cannot definition when comparing class" do
     @ability.can :read, Range


### PR DESCRIPTION
Consider the classes:

```
class Foo
   attr_accessor :my_bar
end

class Bar
   def baz; "quux"; end
end
```

The ability:

```
 can :manage, Foo, :bar => { :baz => "quux" }
```

And the check:

```
foo_without_bar = Foo.new
foo_without_bar.bar #  => nil
can? :manage, foo_without_bar # => Exception!
```

In 1.6.4 this results in the exception `undefined method 'bar' for nil:NilClass`.  This patch modifies the Rule#matches_conditions_hash? to return false for this case.

Test included, and comments are welcome.  Thanks!
