### PR TITLE
Adds ability to use Scope query with Mongoid

### DIFF
--- a/lib/cancan/model_adapters/mongoid_adapter.rb
+++ b/lib/cancan/model_adapters/mongoid_adapter.rb
@@ -18,6 +18,8 @@ module CanCan
       def database_records
         if @rules.size == 0  
           @model_class.where(:_id => {'$exists' => false, '$type' => 7}) # return no records in Mongoid
+        elsif @rules.size == 1 && @rules[0].conditions.is_a?(Mongoid::Criteria)
+          @rules[0].conditions
         else
           @rules.inject(@model_class.all) do |records, rule|
             if rule.conditions.empty?

--- a/spec/cancan/model_adapters/mongoid_adapter_spec.rb
+++ b/spec/cancan/model_adapters/mongoid_adapter_spec.rb
@@ -68,6 +68,14 @@ if ENV["MODEL_ADAPTER"] == "mongoid"
         MongoidProject.accessible_by(@ability, :read).entries.should == [sir, lord, dude]
       end
 
+      it "should allow a scope for conditions" do
+        @ability.can :read, MongoidProject, MongoidProject.where(:title => 'Sir')
+        sir   = MongoidProject.create(:title => 'Sir')
+        lord  = MongoidProject.create(:title => 'Lord')
+        dude  = MongoidProject.create(:title => 'Dude')
+
+        MongoidProject.accessible_by(@ability, :read).entries.should == [sir]
+      end
 
       describe "Mongoid::Criteria where clause Symbol extensions using MongoDB expressions" do
         it "should handle :field.in" do


### PR DESCRIPTION
Small enhancement to the mongoid_adapter to allow the use of scopes like with ActiveRecord.

Passes all cancan specs plus fixed the specs in my application.

Same limitations apply as with active record:
*can not be OR'd with other rules for same ability/controller
