### PR TITLE
Augments Mongoid adapter by handling case where attribute is an array

### DIFF
--- a/lib/cancan/model_adapters/mongoid_adapter.rb
+++ b/lib/cancan/model_adapters/mongoid_adapter.rb
@@ -6,7 +6,14 @@ module CanCan
       end
 
       def self.override_conditions_hash_matching?(subject, conditions)
-        conditions.any? { |k,v| !k.kind_of?(Symbol) }
+        conditions.any? do |k,v|
+          key_is_not_symbol = lambda { !k.kind_of?(Symbol) }
+          subject_value_is_array = lambda do
+            subject.respond_to?(k) && subject.send(k).is_a?(Array)
+          end
+
+          key_is_not_symbol.call || subject_value_is_array.call
+        end
       end
 
       def self.matches_conditions_hash?(subject, conditions)

--- a/spec/cancan/model_adapters/mongoid_adapter_spec.rb
+++ b/spec/cancan/model_adapters/mongoid_adapter_spec.rb
@@ -42,6 +42,15 @@ if ENV["MODEL_ADAPTER"] == "mongoid"
         @ability.should be_able_to(:read, model)
       end
 
+      it "should be able to read hashes when field is array" do
+        one_to_three = MongoidProject.create(:numbers => ['one', 'two', 'three'])
+        two_to_five  = MongoidProject.create(:numbers => ['two', 'three', 'four', 'five'])
+
+        @ability.can :foo, MongoidProject, :numbers => 'one'
+        @ability.should be_able_to(:foo, one_to_three)
+        @ability.should_not be_able_to(:foo, two_to_five)
+      end
+
       it "should return [] when no ability is defined so no records are found" do
         MongoidProject.create(:title => 'Sir')
         MongoidProject.create(:title => 'Lord')


### PR DESCRIPTION
The Mongoid adapter only delegates when the keys of a conditions hash are not symbols, so most of the time, whether a `can` rule matches or not is determined by `lib/cancan/rule.rb` when you're using Mongoid. Unfortunately, it doesn't handle all the cases well. In particular, when the field you're matching against is an array, an erroneous match is returned, but that's not the behavior when you use Mongoid itself.

In other words, when you do something like the following, you won't get what you expect:

``` ruby
basket = Basket.create(:fruits => ['apple', 'banana', 'orange'])

can :eat, Basket, :fruits => 'apple'
# ...
@ability.should be_able_to(:eat, basket) # fail! doesn't match basket
```

However, in Mongoid, this is a legal criterion:

``` ruby
Basket.where(:fruits => 'apple').first == basket # => true
```

This pull request fixes the problem. A spec that illustrates this problem is attached to the pull request, which will fail if you revert the change to the adapter.
