### PR TITLE
This fixes the problem, when the conditions wouldn't return a string of t

### DIFF
--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -56,8 +56,8 @@ module CanCan
           # Return the conditions directly if there's just one definition
           tableized_conditions(@rules.first.conditions).dup
         else
-          @rules.reverse.inject(false_sql) do |sql, rule|
-            merge_conditions(sql, tableized_conditions(rule.conditions).dup, rule.base_behavior)
+          @rules.reverse.inject(false_sql) do |sql, rule, result|
+            result = "#{result} #{merge_conditions(sql, tableized_conditions(rule.conditions).dup, rule.base_behavior)}"
           end
         end
       end


### PR DESCRIPTION
This fixes the problem when the conditions method wouldn't return a string of the SQL script. However, the script always contains "OR ( 1=1)" by default which should also be fixed.
