### PR TITLE
This fix solved issue #204. Thanks

### DIFF
--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -111,7 +111,7 @@ module CanCan
 
       def merge_conditions(sql, conditions_hash, behavior)
         if conditions_hash.blank?
-          behavior ? true_sql : false_sql
+          behavior ? false_sql : true_sql
         else
           conditions = sanitize_sql(conditions_hash)
           case sql


### PR DESCRIPTION
I'm sorry for the many pull requests, it took me some time to fully understand your code.
I think the logic makes more sense with the change I've suggested, and all my problems are therefore fixed.

At first I thought the inject function was messing up, but it turned out it was due to some other modifications I've done on my local version of CanCan.

In the merge_conditions method if the conditions_hash is blank, the output should be false_sql and be skipped if any other iteration is required (follow the logic). However, in the current version of CanCan, when the conditions_hash is blank, the output is set to true_sql, which would not skip the blank condition and actually modify the logic of the next iteration (get stuck in a loop and only output (1=1)).

My fix has been reviewed many times, and it works. There will be no more pull requests, and I'm sorry about the last useless pull requests. 
