### PR TITLE
Make CanCan Default Message a translatable text.

### DIFF
--- a/lib/cancan/exceptions.rb
+++ b/lib/cancan/exceptions.rb
@@ -40,7 +40,7 @@ module CanCan
       @message = message
       @action = action
       @subject = subject
-      @default_message = I18n.t(:"cancan.default_message", :default => "You are not authorized to access this page.")
+      @default_message = I18n.t(:"unauthorized.default", :default => "You are not authorized to access this page.")
     end
 
     def to_s

--- a/spec/cancan/exceptions_spec.rb
+++ b/spec/cancan/exceptions_spec.rb
@@ -39,7 +39,7 @@ describe CanCan::AccessDenied do
     end
     
     it "uses i18n for the default message" do
-      I18n.backend.store_translations :en, :cancan => {:default_message => "This is a different message"}
+      I18n.backend.store_translations :en, :unauthorized => {:default => "This is a different message"}
       @exception = CanCan::AccessDenied.new
       @exception.message.should == "This is a different message"
     end


### PR DESCRIPTION
Make CanCan Default Message a translatable text. Default to the one you had.
