### PR TITLE
Load datamapper class methods via append_extensions.

### DIFF
--- a/lib/cancan/model_adapters/data_mapper_adapter.rb
+++ b/lib/cancan/model_adapters/data_mapper_adapter.rb
@@ -31,6 +31,4 @@ module CanCan
   end # module ModelAdapters
 end # module CanCan
 
-DataMapper::Model.class_eval do
-  include CanCan::ModelAdditions::ClassMethods
-end
+DataMapper::Model.append_extensions(CanCan::ModelAdditions::ClassMethods)


### PR DESCRIPTION
This relaxes the previous requirement that cancan has to be loaded
before any models are. append_extensions will apply to all
previously loaded models as well as ones loaded after.
