### PR TITLE
Compatibility fix for rspec-instafail and rspec1

### DIFF
--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -1,5 +1,5 @@
-RSpec = Spec unless defined? RSpec # for RSpec 1 compatability
-RSpec::Matchers.define :be_able_to do |*args|
+rspec_module = defined?(RSpec::Core) ? 'RSpec' : 'Spec'  # for RSpec 1 compatability
+Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
   match do |ability|
     ability.can?(*args)
   end


### PR DESCRIPTION
Please see issue: #420

Summary: the existing compatibility fix for rspec1 breaks when using rspec-instafail. It defines RSpec module which cancan is using to determine rspec version used.
