### PR TITLE
Fixed typos.

### DIFF
--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -186,7 +186,7 @@ module CanCan
         skip_authorize_resource(*args)
       end
 
-      # Skip both the loading behavior of CanCan. This is useful when using +load_and_authorize_resource+ but want to
+      # Skip the loading behavior of CanCan. This is useful when using +load_and_authorize_resource+ but want to
       # only do authorization on certain actions. You can pass :only and :except options to specify which actions to
       # skip the effects on. It will apply to all actions by default.
       #
@@ -202,7 +202,7 @@ module CanCan
         cancan_skipper[:load][name] = options
       end
 
-      # Skip both the authorization behavior of CanCan. This is useful when using +load_and_authorize_resource+ but want to
+      # Skip the authorization behavior of CanCan. This is useful when using +load_and_authorize_resource+ but want to
       # only do loading on certain actions. You can pass :only and :except options to specify which actions to
       # skip the effects on. It will apply to all actions by default.
       #


### PR DESCRIPTION
I fixed two typos in comments for the methods `skip_load_resource` and `skip_authorize_resource`.
