### PR TITLE
Add .travis.yml for building cancan on a lovely Travis CI service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
-script: "bundle exec rake"
 rvm:
   - 1.8.7
   - 1.9.2
   - jruby
   - ree
   - rbx-2.0
-gemfile:
-  - Gemfile
 notifications:
   recipients:
     - graf.otodrakula@gmail.com


### PR DESCRIPTION
Build cancan over 5 rubies on Travis CI with a simple config file and post-commit hook, but you already know that.

Here's my fork: http://travis-ci.org/#!/bai/cancan
