### PR TITLE
Specs fail when running in a freshly installed environment.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ case ENV["MODEL_ADAPTER"]
 when nil, "active_record"
   gem "sqlite3"
   gem "activerecord", '~> 3.0.9', :require => "active_record"
-  gem "with_model"
+  gem "with_model", '~> 0.1.5'
   gem "meta_where"
 when "data_mapper"
   gem "dm-core", "~> 1.0.2"


### PR DESCRIPTION
I'm getting the following failure when running rspec on the gem project:

```
Failures:
  1) CanCan::ModelAdapters::ActiveRecordAdapter should fetch only associated records when using with a scope for conditions
     Failure/Error: category1.articles.accessible_by(@ability).should == [article1]
     expected: [#<Article id: 1, name: nil, published: nil, secret: true, priority: nil, category_id: 1>],
          got: [] (using ==)
     Diff:
     @@ -1,2 +1,2 @@
     -[#<Article id: 1, name: nil, published: nil, secret: true, priority: nil, category_id: 1>]
     +[]
     # ./spec/cancan/model_adapters/active_record_adapter_spec.rb:139
```

The reason for this error is that [with_model](https://github.com/Casecommons/with_model) version 2.x creates a subclass of the ActiveRecord model you're defining. This results in the `Rule.relevant?` method having trouble identifying which rules apply to the model.

Version 1.x of with_model doesn't have this issue.
