### PR TITLE
Fix "uninitialized constant CanCan::Rule::ModelAdapters"

### DIFF
--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -136,7 +136,7 @@ module CanCan
     end
 
     def model_adapter(subject)
-      ModelAdapters::AbstractAdapter.adapter_class(subject_class?(subject) ? subject : subject.class)
+      CanCan::ModelAdapters::AbstractAdapter.adapter_class(subject_class?(subject) ? subject : subject.class)
     end
   end
 end


### PR DESCRIPTION
Integrating CanCan with Sinatra 1.3 / DataMapper 1.2 / Ruby 1.9.2, I encountered this error. This change fixes it, but I haven't tested with an alternate stack.
