### PR TITLE
Proposing expansion of the find_by scope

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -103,6 +103,8 @@ module CanCan
         if @options[:find_by]
           if resource_base.respond_to? "find_by_#{@options[:find_by]}!"
             resource_base.send("find_by_#{@options[:find_by]}!", id_param)
+          elsif @controller.respond_to? @options[:find_by]
+            @controller.send(@options[:find_by])
           else
             resource_base.send(@options[:find_by], id_param)
           end

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -339,7 +339,7 @@ describe CanCan::ControllerResource do
     lambda { resource.load_and_authorize_resource }.should raise_error(CanCan::AccessDenied)
     @controller.instance_variable_get(:@custom_project).should == project
   end
-  
+
   it "should load resource using custom ID param" do
     project = Project.create!
     @params.merge!(:action => "show", :the_project => project.id)
@@ -347,7 +347,7 @@ describe CanCan::ControllerResource do
     resource.load_resource
     @controller.instance_variable_get(:@project).should == project
   end
-  
+
   it "should load resource using custom find_by attribute" do
     project = Project.create!(:name => "foo")
     @params.merge!(:action => "show", :id => "foo")
@@ -360,6 +360,17 @@ describe CanCan::ControllerResource do
     project = Project.create!(:name => "foo")
     @params.merge!(:action => "show", :id => "foo")
     resource = CanCan::ControllerResource.new(@controller, :find_by => :find_by_name)
+    resource.load_resource
+    @controller.instance_variable_get(:@project).should == project
+  end
+
+  it "should allow full controller level find method to be passed into find_by option" do
+    project = Project.create!(:name => "foo")
+    @params.merge!(:action => "show", :id => "foo")
+
+    stub(@controller).controller_method { project }
+
+    resource = CanCan::ControllerResource.new(@controller, :find_by => :controller_method)
     resource.load_resource
     @controller.instance_variable_get(:@project).should == project
   end


### PR DESCRIPTION
Allow the finder method to be a controller method for increased flexibility.

The use case for this is to allow existing applications to keep their finder
logic, e.g. projects that always want to go through an account scope or
that have logic to manage params for setting include directives on the finder level.

Example:

```
current_account.users.all(
  :conditions => [ "roles = ? AND created_at > ?", params[:roles], 3.days.ago ],
  :include    => safe_params_includes
)
```

Having the ability to surface a finder method in the controller, we do not need
to push knowledge of params structure and the likes into a model.
