### PR TITLE
Use latest with_model gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ case ENV["MODEL_ADAPTER"]
 when nil, "active_record"
   gem "sqlite3"
   gem "activerecord", '~> 3.0.9', :require => "active_record"
-  gem "with_model", '~> 0.1.5'
+  gem "with_model", "~> 0.2.5"
   gem "meta_where"
 when "data_mapper"
   gem "dm-core", "~> 1.0.2"


### PR DESCRIPTION
Now with_model clears the association class cache between specs, which fixes the test pollution problem found in https://github.com/ryanb/cancan/pull/476.
