### PR TITLE
Fix 'spec/spec_helper.rb:20: uninitialized constant WithModel (NameError)'

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ RSpec.configure do |config|
     Project.delete_all
     Category.delete_all
   end
-  config.extend WithModel
+  config.extend WithModel if ENV["MODEL_ADAPTER"].nil? || ENV["MODEL_ADAPTER"] == "active_record"
 end
 
 class Ability


### PR DESCRIPTION
Fixed problem with 'with_model' gem in DataMapper tests and Mongoid tests.
