### PR TITLE
Namespaces support for controller_resources#build_resource

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -214,7 +214,7 @@ module CanCan
     end
 
     def namespaced_resource
-      @name || @params[:controller].sub("Controller", "").underscore.gsub('/', '_').singularize
+      namespaced_name.to_s.underscore.gsub('/', '_').singularize
     rescue
       name
     end


### PR DESCRIPTION
The general problem with namespaced models was solved several months ago with help of "namespaced_name". However cancan still tries to get basic name to retrieve data from params[] on :create actions. This is a tiny fix to improve this behavior.
