### PR TITLE
namespaced models weren't loading params - controller_resources#build_resource

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -82,7 +82,7 @@ module CanCan
     end
 
     def build_resource
-      resource = resource_base.new(@params[name] || {})
+      resource = resource_base.new(resource_params)
       resource.send("#{parent_name}=", parent_resource) if @options[:singleton] && parent_resource
       initial_attributes.each do |attr_name, value|
         resource.send("#{attr_name}=", value)
@@ -90,9 +90,34 @@ module CanCan
       resource
     end
 
+    def resource_params
+      if @params[param_key]
+        @params[param_key]
+      elsif resource_param_key && @params[resource_param_key]
+        @params[resource_param_key]
+      else
+        {}
+      end
+    end
+
+    def param_key
+      @options.has_key?(:param_key) ? @options[:param_key] : name
+    end
+
+    def resource_param_key
+      if defined? ActiveModel
+        case ActiveModel::VERSION::MINOR
+        when 1
+          ActiveModel::Naming.param_key(resource_class)
+        when 0
+          ActiveModel::Naming.singular(resource_class)
+        end
+      end
+    end
+
     def initial_attributes
       current_ability.attributes_for(@params[:action].to_sym, resource_class).delete_if do |key, value|
-        @params[name] && @params[name].include?(key)
+        resource_params.include?(key)
       end
     end
 

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -62,6 +62,20 @@ describe CanCan::ControllerResource do
     @controller.instance_variable_get(:@project).name.should == "foobar"
   end
 
+  it "should build a new resource with hash if params[:id] is not specified (using param_key)" do
+     @params.merge!(:action => "create", :project_x => {:name => "foobar"})
+     resource = CanCan::ControllerResource.new(@controller, :param_key => 'project_x')
+     resource.load_resource
+     @controller.instance_variable_get(:@project).name.should == "foobar"
+   end
+
+  it "should build a new resource with hash if params[:id] is not specified (using ActiveModel::Naming)" do
+    @params.merge!(:controller => 'namespaced/models', :action => "create", :namespaced_model => {:name => "foobar"})
+    resource = CanCan::ControllerResource.new(@controller)
+    resource.load_resource
+    @controller.instance_variable_get(:@model).name.should == "foobar"
+  end
+
   it "should build a new resource with attributes from current ability" do
     @params.merge!(:action => "new")
     @ability.can(:create, Project, :name => "from conditions")
@@ -339,7 +353,7 @@ describe CanCan::ControllerResource do
     lambda { resource.load_and_authorize_resource }.should raise_error(CanCan::AccessDenied)
     @controller.instance_variable_get(:@custom_project).should == project
   end
-  
+
   it "should load resource using custom ID param" do
     project = Project.create!
     @params.merge!(:action => "show", :the_project => project.id)
@@ -347,7 +361,7 @@ describe CanCan::ControllerResource do
     resource.load_resource
     @controller.instance_variable_get(:@project).should == project
   end
-  
+
   it "should load resource using custom find_by attribute" do
     project = Project.create!(:name => "foo")
     @params.merge!(:action => "show", :id => "foo")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,3 +43,8 @@ class Project < SuperModel::Base
     end
   end
 end
+
+module Namespaced
+  class Model < SuperModel::Base
+  end
+end


### PR DESCRIPTION
form_for(@nested) where @nested is an instance of Something::Nested would set the params as something_nested. I changed cancan to use the same method(s) form_for uses. I also added a param_key option in case none of the defaults work.

As I was writing this pull request I noticed
https://github.com/ryanb/cancan/pull/524

Either one works, I figured I added tests so I'd just submit the request anyway. Thanks
