### PR TITLE
Method destructs parameter, unconditionally authorizing the next rule

### DIFF
--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -123,7 +123,7 @@ module CanCan
     end
 
     def nested_subject_matches_conditions?(subject_hash)
-      parent, child = subject_hash.shift
+      parent, child = subject_hash.first
       matches_conditions_hash?(parent, @conditions[parent.class.name.downcase.to_sym] || {})
     end
 


### PR DESCRIPTION
`Rule#nested_subject_matches_conditions?` uses `shift` on its `subject_hash` parameter, destroying it. As this hash contains one element (the hash format is merely syntactic sugar in calls to `can?`), the next rule will get an empty hash, causing it to always return true.

I replaced it with `first`.
