### PR TITLE
Fix #494: Make sure to actually call block with nil when subject is a Class

### DIFF
--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -30,8 +30,12 @@ module CanCan
     def matches_conditions?(action, subject, extra_args)
       if @match_all
         call_block_with_all(action, subject, extra_args)
-      elsif @block && !subject_class?(subject)
-        @block.call(subject, *extra_args)
+      elsif @block
+        if subject_class?(subject)
+          @block.call(nil)
+        else
+          @block.call(subject, *extra_args)
+        end
       elsif @conditions.kind_of?(Hash) && subject.class == Hash
         nested_subject_matches_conditions?(subject)
       elsif @conditions.kind_of?(Hash) && !subject_class?(subject)

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -55,13 +55,16 @@ describe CanCan::Ability do
     @block_called.should be_true
   end
 
-  it "should not call block when only class is passed, only return true" do
+  it "should call block with nil when only class is passed" do
     @block_called = false
+    @passed_object = Object.new
     @ability.can :preview, :all do |object|
       @block_called = true
+      @passed_object = object
     end
-    @ability.can?(:preview, Hash).should be_true
-    @block_called.should be_false
+    @ability.can?(:preview, Hash).should be_false
+    @block_called.should be_true
+    @passed_object.should be_nil
   end
 
   it "should pass only object for global manage actions" do
@@ -283,12 +286,17 @@ describe CanCan::Ability do
   it "should pass nil to a block for ability on Module when no instance is passed" do
     module B; end
     class A; include B; end
+    @block_called = false
+    @passed_arg = Object.new
     @ability.can :read, B do |sym|
-      sym.should be_nil
+      @block_called = true
+      @passed_arg = sym
       true
     end
     @ability.can?(:read, B).should be_true
     @ability.can?(:read, A).should be_true
+    @passed_arg.should be_nil
+    @block_called.should be_true
   end
 
   it "passing a hash of subjects should check permissions through association" do


### PR DESCRIPTION
Since there seemed to be two conflicting specs for can? being called with a Class, one simply returning true and one broken spec for, calling a block, I think I resolved the conflict and fixed #494.  Check the bug and see if this is a fix you agree with.

Thanks!
## 

Ken
