### PR TITLE
initialise attributes after a resource is created by CanCan::InheritedResource

### DIFF
--- a/lib/cancan/inherited_resource.rb
+++ b/lib/cancan/inherited_resource.rb
@@ -6,7 +6,13 @@ module CanCan
         @controller.send :association_chain
         @controller.instance_variable_get("@#{instance_name}")
       elsif new_actions.include? @params[:action].to_sym
-        @controller.send :build_resource
+
+        resource = @controller.send :build_resource
+        initial_attributes.each do |attr_name, value|
+          resource.send("#{attr_name}=", value)
+        end
+        resource
+
       else
         @controller.send :resource
       end


### PR DESCRIPTION
tracking down a problem using CanCan with ActiveAdmin i saw that resources still seem to need initial_attributes setting after controller.build_resource is used to create a new instance of the resource

this patch sets the initial_attributes in the same way the ControllerResource.build_resource does
