### PR TITLE
Port fix for namespaced params from 2.0 back to 1.6

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -82,7 +82,7 @@ module CanCan
     end
 
     def build_resource
-      resource = resource_base.new(@params[name] || {})
+      resource = resource_base.new(resource_params || {})
       resource.send("#{parent_name}=", parent_resource) if @options[:singleton] && parent_resource
       initial_attributes.each do |attr_name, value|
         resource.send("#{attr_name}=", value)
@@ -92,7 +92,7 @@ module CanCan
 
     def initial_attributes
       current_ability.attributes_for(@params[:action].to_sym, resource_class).delete_if do |key, value|
-        @params[name] && @params[name].include?(key)
+        resource_params && resource_params.include?(key)
       end
     end
 
@@ -205,6 +205,11 @@ module CanCan
 
     def name
       @name || name_from_controller
+    end
+
+    def resource_params
+      # since Rails includes the namespace in the params sent by the form (issue #349)
+      @params[namespaced_name.to_s.underscore.gsub("/", "_")]
     end
 
     def namespaced_name

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -47,6 +47,18 @@ describe CanCan::ControllerResource do
     @controller.instance_variable_get(:@project).should == project
   end
 
+  # Rails includes namespace in params, see issue #349
+  it "should create through the namespaced params" do
+    module MyEngine
+      class Project < ::Project; end
+    end
+
+    @params.merge!(:controller => "MyEngine::ProjectsController", :action => "create", :my_engine_project => {:name => "foobar"})
+    resource = CanCan::ControllerResource.new(@controller)
+    resource.load_resource
+    @controller.instance_variable_get(:@project).name.should == "foobar"
+  end
+
   it "should properly load resource for namespaced controller when using '::' for namespace" do
     project = Project.create!
     @params.merge!(:controller => "Admin::ProjectsController", :action => "show", :id => project.id)
@@ -339,7 +351,7 @@ describe CanCan::ControllerResource do
     lambda { resource.load_and_authorize_resource }.should raise_error(CanCan::AccessDenied)
     @controller.instance_variable_get(:@custom_project).should == project
   end
-  
+
   it "should load resource using custom ID param" do
     project = Project.create!
     @params.merge!(:action => "show", :the_project => project.id)
@@ -347,7 +359,7 @@ describe CanCan::ControllerResource do
     resource.load_resource
     @controller.instance_variable_get(:@project).should == project
   end
-  
+
   it "should load resource using custom find_by attribute" do
     project = Project.create!(:name => "foo")
     @params.merge!(:action => "show", :id => "foo")


### PR DESCRIPTION
This is a port of the fix for #349, but back ported to the 1.6 series. Commit: c94de4a

Probably also solves #541, #528, and #524.
