### PR TITLE
False positives on multiple nested abilities definitions

### DIFF
--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -123,7 +123,7 @@ module CanCan
     end
 
     def nested_subject_matches_conditions?(subject_hash)
-      parent, child = subject_hash.shift
+      parent, child = subject_hash.first
       matches_conditions_hash?(parent, @conditions[parent.class.name.downcase.to_sym] || {})
     end
 

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -298,6 +298,14 @@ describe CanCan::Ability do
     @ability.can?(:read, 123 => Range).should be_true
   end
   
+  it "passing a hash of subjects with multiple definitions should check permissions correctly" do
+    @ability.can :read, Range, :string => {:length => 4}
+    @ability.can [:create, :read], Range, :string => {:upcase => 'FOO'}
+    @ability.can?(:read, "foo" => Range).should be_true
+    @ability.can?(:read, "foobar" => Range).should be_false
+    @ability.can?(:read, 1234 => Range).should be_true
+  end  
+  
   it "should allow to check ability on Hash-like object" do
     class Container < Hash; end
     @ability.can :read, Container


### PR DESCRIPTION
Hi Ryan, 

I just found a nasty problem when you have multiple definitions for a nested ability, the can? method always return true. For example :

``` ruby
# ability.rb
can :read, Comment, :post => {:published => true}
can [:read, :update], Comment, :post => {:author_id => user.id}

# checking ability
can? :read, @post => Comment
```

I found out that the rule.rb class is using Hash.shift on the subject. Doing that removes the content from the subject. So when the second rule is tested the subject is empty and the condition matching return true.
In this commit, I simply propose to replace Hash.shift by Enumerable.first as it's not destructive on the subject Hash.

Florent
