### PR TITLE
Just add singleton to description of authorize_resource

### DIFF
--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -151,6 +151,9 @@ module CanCan
       # [:+except+]
       #   Does not apply before filter to given actions.
       #
+      # [:+singleton+]
+      #   Pass +true+ if this is a singleton resource through a +has_one+ association.
+      #
       # [:+parent+]
       #   True or false depending on if the resource is considered a parent resource. This defaults to +true+ if a resource
       #   name is given which does not match the controller.


### PR DESCRIPTION
Inside controller I don't use load_resource and just write authorize_resource. But this controller declared as resource in routing file and I was a bit confused when I was trying to understand why a nil comes to can rule in abilities. And it was because I had missed :singleton => true for authorize_resource.
