### PR TITLE
Fix namespace split

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -237,7 +237,7 @@ module CanCan
     end
 
     def namespace
-      @params[:controller].split("::")[0..-2]
+      @params[:controller].split(/::|\//)[0..-2]
     end
 
     def namespaced_name

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -62,6 +62,17 @@ describe CanCan::ControllerResource do
     @controller.instance_variable_get(:@project).should == project
   end
 
+  it "has the specified nested resource_class when using / for namespace" do
+    module Admin
+      class Dashboard; end
+    end
+    @ability.can(:index, "admin/dashboard")
+    @params.merge!(:controller => "admin/dashboard", :action => "index")
+    @controller.authorize!(:index, "admin/dashboard")
+    resource = CanCan::ControllerResource.new(@controller, :authorize => true)
+    resource.send(:resource_class).should == Admin::Dashboard
+  end
+
   it "builds a new resource with hash if params[:id] is not specified and authorize on each attribute" do
     @params.merge!(:action => "create", :project => {:name => "foobar"})
     CanCan::ControllerResource.new(@controller, :load => true).process


### PR DESCRIPTION
``` rb
#ability.rb
can :index, "admin/dashboard"
```

this code will incorrectly try to load `Dashboard` class, not `Admin::Dashboard` class
