### PR TITLE
Add Code Climate badge

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,4 @@
-= CanCan {<img src="https://secure.travis-ci.org/ryanb/cancan.png" />}[http://travis-ci.org/ryanb/cancan]
+= CanCan {<img src="https://secure.travis-ci.org/ryanb/cancan.png" />}[http://travis-ci.org/ryanb/cancan] {<img src="https://codeclimate.com/badge.png" />}[https://codeclimate.com/github/ryanb/cancan]
 
 Wiki[https://github.com/ryanb/cancan/wiki] | RDocs[http://rdoc.info/projects/ryanb/cancan] | Screencast[http://railscasts.com/episodes/192-authorization-with-cancan]
 


### PR DESCRIPTION
Hi,

I just fully launched Code Climate's free-for-OSS support. Code Climate is a service that hosts code quality metrics for Ruby apps and libraries.

Someone has already added CanCan, so you can view its metrics here:

```
https://codeclimate.com/github/ryanb/cancan
```

I put together a quick pull request to add a badge/link to Code Climate from the README, in case you want to make this information available to contributors.

Please let me know if you have any questions.

Cheers,

-Bryan
