### PR TITLE
spec & fix for params[:controller] in underscore format

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -227,7 +227,7 @@ module CanCan
     end
 
     def namespace
-      @params[:controller].split("::")[0..-2]
+      @params[:controller].camelize.split("::")[0..-2]
     end
 
     def namespaced_name
@@ -237,7 +237,7 @@ module CanCan
     end
 
     def name_from_controller
-      @params[:controller].sub("Controller", "").underscore.split('/').last.singularize
+      @params[:controller].camelize.sub("Controller", "").underscore.split('/').last.singularize
     end
 
     def instance_name

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -56,7 +56,7 @@ describe CanCan::ControllerResource do
     @params.merge!(:controller => "my_engine/projects_controller", :action => "show", :id => project.id)
     resource = CanCan::ControllerResource.new(@controller)
     resource.load_resource
-    @controller.instance_variable_get(:@project).should == project
+    @controller.instance_variable_get(:@project).should eq project
   end
 
   # Rails includes namespace in params, see issue #349

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -47,6 +47,18 @@ describe CanCan::ControllerResource do
     @controller.instance_variable_get(:@project).should == project
   end
 
+  it "should attempt to load a resource with the same namespace as the controller when using / for namespace" do
+    module MyEngine
+      class Project < ::Project; end
+    end
+
+    project = MyEngine::Project.create!
+    @params.merge!(:controller => "my_engine/projects_controller", :action => "show", :id => project.id)
+    resource = CanCan::ControllerResource.new(@controller)
+    resource.load_resource
+    @controller.instance_variable_get(:@project).should == project
+  end
+
   # Rails includes namespace in params, see issue #349
   it "should create through the namespaced params" do
     module MyEngine


### PR DESCRIPTION
code supposed that @params[:controller] is in camel case, but actually in rails it's in snake case

so i added .camelize in some methods