### PR TITLE
@_cancan_skipper should be inherited

### DIFF
--- a/spec/cancan/controller_additions_spec.rb
+++ b/spec/cancan/controller_additions_spec.rb
@@ -134,4 +134,25 @@ describe CanCan::ControllerAdditions do
     @controller_class.cancan_skipper[:load][:project].should == {:only => [:index, :show]}
     @controller_class.cancan_skipper[:authorize][:project].should == {:only => [:index, :show]}
   end
+
+  describe "when inheriting" do
+    before(:each) do
+      @super_controller_class = Class.new
+      @super_controller = @super_controller_class.new
+      mock(@super_controller_class).helper_method(:can?, :cannot?, :current_ability)
+      @super_controller_class.send(:include, CanCan::ControllerAdditions)
+      @super_controller_class.send(:skip_load_and_authorize_resource, :only => [:index, :show])
+
+      @sub_controller_class = Class.new(@super_controller_class)
+      @sub_controller = @sub_controller_class.new
+    end
+
+    it "sub_classes should skip the same behaviors and actions as super_classes" do
+      @super_controller_class.cancan_skipper[:load][nil].should == {:only => [:index, :show]}
+      @super_controller_class.cancan_skipper[:authorize][nil].should == {:only => [:index, :show]}
+
+      @sub_controller_class.cancan_skipper[:load][nil].should == {:only => [:index, :show]}
+      @sub_controller_class.cancan_skipper[:authorize][nil].should == {:only => [:index, :show]}
+    end
+  end
 end


### PR DESCRIPTION
If a superclass controller has:

```
load_and_authorize_resource
skip_load_resource :only => :index
```

A subclass will not skip the loading of the resource on the `index` action.

I've added a failing test to illustrate this behavior.

Potential fix would be to use `class_attribute` from Rails: http://apidock.com/rails/Class/class_attribute
