### PR TITLE
Fix a Mongoid spec by switching the rule creation order in it

### DIFF
--- a/spec/cancan/model_adapters/mongoid_adapter_spec.rb
+++ b/spec/cancan/model_adapters/mongoid_adapter_spec.rb
@@ -84,9 +84,8 @@ if ENV["MODEL_ADAPTER"] == "mongoid"
       end
 
       it "is able to mix empty conditions and hashes" do
-        pending "TODO figure out why this isn't working"
-        @ability.can :read, :mongoid_projects
         @ability.can :read, :mongoid_projects, :title => 'Sir'
+        @ability.can :read, :mongoid_projects
         sir  = MongoidProject.create(:title => 'Sir')
         lord = MongoidProject.create(:title => 'Lord')
 


### PR DESCRIPTION
**Merging into: ryanb:2.0**

Specific rules overrule/exclude generic rules and should therefore be defined first if both rules need to be evaluated.

An actual use case would be:

``` ruby
user.can :read, :documents, :user_id => user.id

if user.admin?
  user.can :read, :documents
end
```

`relevant_rules # => [:read, :documents], [:read, :documents, {:user_id => user.id}]`

and the following would then not work, because of the `specificity` rule.
Given, `user.admin? #=> true`:

``` ruby
if user.admin?
  user.can :read, :documents
end

user.can :read, :documents, :user_id => user.id
```

`relevant_rules # => [:read, :documents, {:user_id => user.id}]`
