### PR TITLE
Being able to specify a method name (of the ability) used for checking abilities (instead of procs)

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -121,8 +121,11 @@ module CanCan
     #     # check the database and return true/false
     #   end
     #
-    def can(action = nil, subject = nil, conditions = nil, &block)
-      rules << Rule.new(true, action, subject, conditions, block)
+    def can(action = nil, subject = nil, conditions = nil, method = nil, &block)
+      if method && block_given?
+        raise ArgumentError, "You cannot pass both a block and a mapped method when defining an ability"
+      end
+      rules << Rule.new(true, action, subject, conditions, method || block, self)
     end
 
     # Defines an ability which cannot be done. Accepts the same arguments as "can".
@@ -137,8 +140,11 @@ module CanCan
     #     product.invisible?
     #   end
     #
-    def cannot(action = nil, subject = nil, conditions = nil, &block)
-      rules << Rule.new(false, action, subject, conditions, block)
+    def cannot(action = nil, subject = nil, conditions = nil, method = nil, &block)
+      if method && block_given?
+        raise ArgumentError, "You cannot pass both a block and a mapped method when defining an inability"
+      end
+      rules << Rule.new(false, action, subject, conditions, method || block, self)
     end
 
     # Alias one or more actions into another one.

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -391,7 +391,7 @@ describe CanCan::Ability do
       @ability.can :read, Array, :published => true do
         false
       end
-    }.should raise_error(CanCan::Error, "You are not able to supply a block or method with a hash of conditions in read Array ability. Use either one.")
+    }.should raise_error(CanCan::Error, "You are not able to supply a block with a hash of conditions in read Array ability. Use either one.")
   end
 
   describe "unauthorized message" do
@@ -453,7 +453,7 @@ describe CanCan::Ability do
   describe "method mapping" do
     class Foo
       include CanCan::Ability
-      def evaluate(instance)
+      def evaluate(instance, conditions)
         instance == "A"
       end
     end

--- a/spec/cancan/rule_spec.rb
+++ b/spec/cancan/rule_spec.rb
@@ -44,4 +44,14 @@ describe CanCan::Rule do
 
     @rule.should be_unmergeable
   end
+
+  it "should be able to accept the name of a mapped method" do
+    rule = CanCan::Rule.new(true, :read, Integer, nil, :evaluate)
+    rule.instance_variable_get(:@block).should be nil
+    rule.instance_variable_get(:@method).should be :evaluate
+
+    rule = CanCan::Rule.new(true, :read, Integer, nil, proc{})
+    rule.instance_variable_get(:@block).should_not be nil
+    rule.instance_variable_get(:@method).should be nil
+  end
 end


### PR DESCRIPTION
Currently, it isn't possible to Marshal.dump ability instances with "procced abilities".

``` ruby
class Foo
  include CanCan::Ability
end

foo = Foo.new
foo.can :read, String, nil do |instance|
  # do something
end

Marshal.dump foo
=> TypeError: no marshal_dump is defined for class Proc
```

So instead of providing a proc, I have made it possible to specify a method of the ability instance used for checking abilities.

``` ruby
class Foo
  include CanCan::Ability
  def evaluate(instance, conditions)
    # do something
  end
end

foo = Foo.new
foo.can :read, String, nil, :evaluate

Marshal.dump foo
=> "\x04\bo:\bFoo\x06:\v@rules[\x06o:\x11CanCan::Rule\f:\x0F@match_allF:\x13@base_behaviorT:\r@actions[\x06:\tread:\x0E@subjects[\x06c\vString:\x10@conditions{\x00:\f@method:\revaluate:\r@ability@\x00"
```
