### PR TITLE
Fixed load_resource "find_by" in mongoid resources

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -107,6 +107,8 @@ module CanCan
         if @options[:find_by]
           if resource_base.respond_to? "find_by_#{@options[:find_by]}!"
             resource_base.send("find_by_#{@options[:find_by]}!", id_param)
+          elsif resource_base.respond_to? "find_by"
+            resource_base.send("find_by", { @options[:find_by].to_sym => id_param })
           else
             resource_base.send(@options[:find_by], id_param)
           end


### PR DESCRIPTION
Latest versions of Mongoid supports "find_by" query, but syntax is slightly different than Active Record.

http://mongoid.org/en/mongoid/docs/querying.html#queries

Without this patch I could not use "find_by" option in load_and_authorize_resource filter.
