### PR TITLE
Fetched records should match the most liberally defined ability

### DIFF
--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -89,7 +89,7 @@ module CanCan
         if override_scope
           @model_class.scoped.merge(override_scope)
         elsif @model_class.respond_to?(:where) && @model_class.respond_to?(:joins)
-          mergeable_conditions = @rules.select {|rule| rule.unmergeable? }.blank?
+          mergeable_conditions = conditions == true_sql || @rules.select {|rule| rule.unmergeable? }.blank?
           if mergeable_conditions
             @model_class.where(conditions).joins(joins)
           else

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -109,6 +109,14 @@ if ENV["MODEL_ADAPTER"].nil? || ENV["MODEL_ADAPTER"] == "active_record"
       Comment.accessible_by(@ability).should == [comment1]
     end
 
+    it "should fetch articles matching the most liberal ability" do
+      @ability.can :read, Article
+      @ability.can :read, Article, :published => true
+      article1 = Article.create!(:published => true)
+      article2 = Article.create!(:published => false)
+      Article.accessible_by(@ability).should == [article1, article2]
+    end
+
     it "should allow conditions in SQL and merge with hash conditions" do
       @ability.can :read, Article, :published => true
       @ability.can :read, Article, ["secret=?", true]


### PR DESCRIPTION
I ran into what appears to be a regression occurring somewhere between 1.6.5 and 1.6.8. Basically, I had defined abilities in my app something like this:

```
if user.role? :admin
  can :manage, :all
elsif user.role? :other
  #...
end

can :manage, Something, :user_id => user.id
```

The purpose of this is to say, "Admins can do anything, other users with roles can do 'such and such', and all users can manage their own Somethings". In 1.6.5 this worked great, with the `accessible_by` method returned "owned" models for general users and all models for admins. In 1.6.8 it would essentially "prefer" the last defined ability and only return "owned" models for every user (including admins).

I believe this has to do with the "mergeable conditions" feature introduced at some point. It doesn't take into account that there is a "super condition" in effect if it determines the conditions are not mergeable. Attached is a pull request with spec that fixes my problem, but it may or may not be the best solution due to my limited understanding / experience w/ this code. Also, I haven't used data mapper or mongoid, so I didn't even attempt to address any issues there.

As always, thanks for the GREAT lib!

(Just realized I didn't do a great job looking through existing pull requests / issues, so I hope I didn't waste my time here... But I AM glad @travisbot likes me! :P
