### PR TITLE
Store attribute in CanCan::Unauthorized exception

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -204,7 +204,7 @@ module CanCan
       attribute = args.first
       if cannot?(action, subject, *args)
         message ||= unauthorized_message(action, subject)
-        raise Unauthorized.new(message, action, subject)
+        raise Unauthorized.new(message, action, subject, attribute)
       elsif sufficient_attribute_check?(action, subject, attribute) && sufficient_condition_check?(action, subject)
         fully_authorized!(action, subject)
       end

--- a/lib/cancan/exceptions.rb
+++ b/lib/cancan/exceptions.rb
@@ -36,13 +36,14 @@ module CanCan
   # See ControllerAdditions#authorize! for more information on rescuing from this exception
   # and customizing the message using I18n.
   class Unauthorized < Error
-    attr_reader :action, :subject
+    attr_reader :action, :subject, :attribute
     attr_writer :default_message
 
-    def initialize(message = nil, action = nil, subject = nil)
+    def initialize(message = nil, action = nil, subject = nil, attribute = nil)
       @message = message
       @action = action
       @subject = subject
+      @attribute = attribute
       @default_message = I18n.t(:"unauthorized.default", :default => "You are not authorized to access this page.")
     end
 

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -408,6 +408,19 @@ describe CanCan::Ability do
       e.message.should == "Access denied!"
       e.action.should == :read
       e.subject.should == :books
+      e.attribute.should be_nil
+    else
+      fail "Expected CanCan::Unauthorized exception to be raised"
+    end
+  end
+
+  it "raises CanCan::Unauthorized when calling authorize! on unauthorized attribute" do
+    begin
+      @ability.authorize! :read, :books, :title
+    rescue CanCan::Unauthorized => e
+      e.action.should == :read
+      e.subject.should == :books
+      e.attribute.should == :title
     else
       fail "Expected CanCan::Unauthorized exception to be raised"
     end

--- a/spec/cancan/exceptions_spec.rb
+++ b/spec/cancan/exceptions_spec.rb
@@ -1,6 +1,18 @@
 require "spec_helper"
 
 describe CanCan::Unauthorized do
+  describe "with action, subject, and attribute" do
+    before(:each) do
+      @exception = CanCan::Unauthorized.new(nil, :some_action, :some_subject, :some_attr)
+    end
+
+    it "has action, subject, and attribute accessors" do
+      @exception.action.should == :some_action
+      @exception.subject.should == :some_subject
+      @exception.attribute.should == :some_attr
+    end
+  end
+
   describe "with action and subject" do
     before(:each) do
       @exception = CanCan::Unauthorized.new(nil, :some_action, :some_subject)
@@ -9,6 +21,7 @@ describe CanCan::Unauthorized do
     it "has action and subject accessors" do
       @exception.action.should == :some_action
       @exception.subject.should == :some_subject
+      @exception.attribute.should be_nil
     end
 
     it "has a changable default message" do
@@ -23,9 +36,10 @@ describe CanCan::Unauthorized do
       @exception = CanCan::Unauthorized.new("Access denied!")
     end
 
-    it "has nil action and subject" do
+    it "has nil action, subject, and attribute" do
       @exception.action.should be_nil
       @exception.subject.should be_nil
+      @exception.attribute.should be_nil
     end
 
     it "has passed message" do


### PR DESCRIPTION
Stores the attribute for which authorized in fails in the raised CanCan::Unauthorized when calling ability.authorize!

This should help with error messages and debugging.