### PR TITLE
Support for multiparameter attributes (used by datetime_select and time_select)

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -306,6 +306,9 @@ module CanCan
     # Returns an array of Rule instances which match the action and subject
     # This does not take into consideration any hash conditions or block statements
     def relevant_rules(action, subject, attribute = nil)
+      if attribute
+        attribute = attribute.to_s.split('(').first.to_sym
+      end
       specificity = 0
       rules.reverse.each_with_object([]) do |rule, relevant_rules|
         rule.expanded_actions = expand_aliases(:actions, rule.actions)

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -224,6 +224,20 @@ describe CanCan::Ability do
     @ability.can?(:update, :users, "name").should be_true
   end
 
+  it "understands multiparameter attributes as strings" do
+    @ability.can :update, :users, :date
+    @ability.can?(:update, :users, "date(i1)").should be_true
+    @ability.can?(:update, :users, "date(i2)").should be_true
+    @ability.can?(:update, :users, "date(i3)").should be_true
+  end
+
+  it "understands multiparameter attributes as symbols" do
+    @ability.can :update, :users, :date
+    @ability.can?(:update, :users, :"date(i1)").should be_true
+    @ability.can?(:update, :users, :"date(i2)").should be_true
+    @ability.can?(:update, :users, :"date(i3)").should be_true
+  end
+
   it "combines attribute check with conditions hash" do
     @ability.can :update, :ranges, :begin => 1
     @ability.can :update, :ranges, :name, :begin => 2


### PR DESCRIPTION
Fixes issue #634

When using a datetime_select or a time_select, the attribute is split into multiple parameters (one per select tag) like `{"date(1i)"=>"2012", "date(2i)"=>"8", "date(3i)"=>"12"}`

This allows datetime_select and time_select to work as expected by making
`@ability.can :update, :article, :date`
allow
```
@ability.can? :update, :article, 'date(1i)'
@ability.can? :update, :article, 'date(2i)'
@ability.can? :update, :article, 'date(3i)'
```
