### PR TITLE
Using singular subject in exception message

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -214,7 +214,7 @@ module CanCan
     def unauthorized_message(action, subject)
       keys = unauthorized_message_keys(action, subject)
       variables = {:action => action.to_s}
-      variables[:subject] = (subject.kind_of?(Symbol) ? subject.to_s : subject.class.to_s.underscore.humanize.downcase.pluralize)
+      variables[:subject] = (subject.kind_of?(Symbol) ? subject.to_s : subject.class.to_s.underscore.humanize.downcase)
       message = I18n.translate(nil, variables.merge(:scope => :unauthorized, :default => keys + [""]))
       message.blank? ? nil : message
     end


### PR DESCRIPTION
The keys in the translation files are still the new 2.0 style (plural) but the subject being returned by the exception message shouldn't be plural. This makes this possible:

``` ruby
en:
  unauthorized:
    access:
      all: 'You do not have permission to %{action} this %{subject}.'
```

Maybe your intent was to use plural subjects here (e.g. ... have permission to edit comments) but in general you're only asking if the user can edit a singular object, not if they can edit comments in general (instance vs class object).  If this is your intent I purpose a subject_plural key or similar as there is no way to run code on translation variables.
