### PR TITLE
skip_load_and_authorize_resource does not raises any exception.

### DIFF
--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -187,8 +187,10 @@ module CanCan
       #
       # You can also pass the resource name as the first argument to skip that resource.
       def skip_load_and_authorize_resource(*args)
-        skip_load_resource(*args)
-        skip_authorize_resource(*args)
+        options = args.extract_options!
+        name = args.first
+        cancan_skipper[:load][name] = options
+        cancan_skipper[:authorize][name] = options
       end
 
       # Skip the loading behavior of CanCan. This is useful when using +load_and_authorize_resource+ but want to


### PR DESCRIPTION
Previously, `skip_load_and_authorize_resource` raised implementation exceptions due to deprecation of `skip_load_resource` and `skip_authorize_resource`.

Implementation's been moved up from these methods to  `skip_load_and_authorize_resource`.

This should fix issue #465
