### PR TITLE
Default subjects to :all when action is provided

### DIFF
--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -12,6 +12,8 @@ module CanCan
     # of conditions and the last one is the block passed to the "can" call.
     def initialize(base_behavior, action, subject, conditions, block)
       raise Error, "You are not able to supply a block with a hash of conditions in #{action} #{subject} ability. Use either one." if conditions.kind_of?(Hash) && !block.nil?
+      subject = :all if !action.nil? && subject.nil?
+
       @match_all = action.nil? && subject.nil?
       @base_behavior = base_behavior
       @actions = [action].flatten

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -394,6 +394,13 @@ describe CanCan::Ability do
     }.should raise_error(CanCan::Error, "You are not able to supply a block with a hash of conditions in read Array ability. Use either one.")
   end
 
+  it "should default subjects to :all if action is provided" do
+    @ability.can :count
+    @ability.can?(:count, 123).should be_true
+    @ability.can?(:count, String).should be_true
+    @ability.can?(:count, :anything).should be_true
+  end
+
   describe "unauthorized message" do
     after(:each) do
       I18n.backend = nil


### PR DESCRIPTION
This adds support for:

``` ruby
can :do_something
```

Which is equivalent to:

``` ruby
can :do_something, :all
```

Providing an action but no subjects will currently fail silently when invoked and throw an AccessDenied exception in the controller for non-resourceful actions. Fixes #734.
