### PR TITLE
fixes #750 - load hooks return ActiveRecord::Model in Rails 4, use Concern

### DIFF
--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -165,6 +165,8 @@ module CanCan
   end
 end
 
-ActiveRecord::Base.class_eval do
-  include CanCan::ModelAdditions
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.class_eval do
+    include CanCan::ModelAdditions
+  end
 end

--- a/lib/cancan/model_additions.rb
+++ b/lib/cancan/model_additions.rb
@@ -2,6 +2,8 @@ module CanCan
 
   # This module adds the accessible_by class method to a model. It is included in the model adapters.
   module ModelAdditions
+    extend ActiveSupport::Concern
+
     module ClassMethods
       # Returns a scope which fetches only the records that the passed ability
       # can perform a given action on. The action defaults to :index. This
@@ -22,10 +24,6 @@ module CanCan
       def accessible_by(ability, action = :index)
         ability.model_adapter(self, action).database_records
       end
-    end
-
-    def self.included(base)
-      base.extend ClassMethods
     end
   end
 end


### PR DESCRIPTION
@ryanb -- this seems to fix the load issue when running under Rails 4. Tests are passing. But should this be approached differently, specifically, should we be adding `accessible_by` to `ActiveRecord::Model` instead of `Base`?
