### PR TITLE
Solves problem when authorizing new action.

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -85,10 +85,11 @@ module CanCan
     end
 
     def assign_attributes(resource)
-      resource.send("#{parent_name}=", parent_resource) if @options[:singleton] && parent_resource
       initial_attributes.each do |attr_name, value|
         resource.send("#{attr_name}=", value)
       end
+
+      resource.send("#{parent_name}=", parent_resource) if @options[:singleton] && parent_resource
       resource
     end
 


### PR DESCRIPTION
Given two models Category and Projects. A Category has_many
projects and Project belongs_to a category. Furthermore,
projects are shallow nested resources in a category.

Let's say that a user can edit certain category's projects
(and only one category can be edited by each user [1]), this is
expressed with the following line in Ability model:

can :new, :projects, category_id: user.category_id

Given the old implementation, we get that any user can 'new'
(though not 'create') a project in any category:

``` ruby
def assign_attributes(resource)
  resource.send("#{parent_name}=", parent_resource) if @options[:singleton] && parent_resource
  initial_attributes.each do |attr_name, value|
    resource.send("#{attr_name}=", value)
  end
  resource
end
```

In this case, category_id in project would get overwritten
inside the initial_attributes loop and authorization would pass.
I consider this a buggy behaviour.

[1] User belongs_to a category, and a Category has many
users. On the other hand, there might be users without
any category.
