### PR TITLE
Allow override resource params

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -212,6 +212,7 @@ module CanCan
     end
 
     def resource_params
+      return @controller.send(:resource_params) if @controller.respond_to?(:resource_params)
       if @options[:class]
         params_key = extract_key(@options[:class])
         return @params[params_key] if @params[params_key]

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -471,4 +471,17 @@ describe CanCan::ControllerResource do
     lambda { resource.load_and_authorize_resource }.should_not raise_error
     @controller.instance_variable_get(:@project).should be_nil
   end
+
+  it "should allow override resource_params" do
+    @params.merge!(:action => "new", :project => {:title => "title"})
+    @controller.instance_exec do
+      def resource_params
+        # params.require(:project).permit(:title, :body)
+        params[:project][:body] = "body"
+      end
+    end
+    resource = CanCan::ControllerResource.new(@controller, :project)
+    resource.load_resource
+    @params[:project][:body].should == "body"
+  end
 end

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -476,7 +476,7 @@ describe CanCan::ControllerResource do
     @params.merge!(:action => "new", :project => {:title => "title"})
     @controller.instance_exec do
       def resource_params
-        # params.require(:project).permit(:title, :body)
+        # params.require(:project).permit(:title, :body) if params[:project]
         params[:project][:body] = "body"
       end
     end


### PR DESCRIPTION
Allow override resource_params in controller so that it makes cancan easily work with strong_parameters.

Here is an example how I use cancan with strong_parameters.

```
class PostsController < ApplicationController
  load_and_authorize_resource
  # new, create, edit, update actions
  protected
    def resource_params
      params.require(:post).permit(:title, :description, :tag_list, post_body_attributes: [:body]) if params[:post]
    end
end
```
