### PR TITLE
2.0

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -235,7 +235,7 @@ module CanCan
     # `resource_params` method.
     #
     def resource_params
-      params = @controller.try(:resource_params)
+      params = @controller.try(:resource_params) if @controller.respond_to?(:resource_params)
       params ||= if @options[:class]
         @params[@options[:class].to_s.underscore.gsub('/', '_')]
       else


### PR DESCRIPTION
Allows the controller to overwrite `resource_params`. 

This is done to allow the user to have better control of the allowed parameters that gets parsed to the model resource.

In my case I'm running rails 4, and needed to be able to parse a `Actioncontroller::Parameters` (strong parameters) hash to the resource, instead of a regular one, in order to parse rails 4's sanitizer. 

So my `resource_params`' method looks something like this:

```
def resource_params
  unless request.get?
    params.require(:user).permit(:email, :name, :password, :password_confirmation)
  end
end
```

If you have any input, please let me know.

Best regards, Emil
