### PR TITLE
Include attribute in CanCan::Unauthorized exception

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -204,7 +204,7 @@ module CanCan
       attribute = args.first
       if cannot?(action, subject, *args)
         message ||= unauthorized_message(action, subject)
-        raise Unauthorized.new(message, action, subject)
+        raise Unauthorized.new(message, action, subject, attribute)
       elsif sufficient_attribute_check?(action, subject, attribute) && sufficient_condition_check?(action, subject)
         fully_authorized!(action, subject)
       end

--- a/lib/cancan/exceptions.rb
+++ b/lib/cancan/exceptions.rb
@@ -18,7 +18,7 @@ module CanCan
   # This usually happens within a call to ControllerAdditions#authorize! but can be
   # raised manually.
   #
-  #   raise CanCan::Unauthorized.new("Not authorized!", :read, Article)
+  #   raise CanCan::Unauthorized.new("Not authorized!", :read, Article, :name)
   #
   # The passed message, action, and subject are optional and can later be retrieved when
   # rescuing from the exception.
@@ -26,6 +26,7 @@ module CanCan
   #   exception.message # => "Not authorized!"
   #   exception.action # => :read
   #   exception.subject # => Article
+  #   exception.attribute # => :name
   #
   # If the message is not specified (or is nil) it will default to "You are not authorized
   # to access this page." This default can be overridden by setting default_message.
@@ -36,13 +37,14 @@ module CanCan
   # See ControllerAdditions#authorize! for more information on rescuing from this exception
   # and customizing the message using I18n.
   class Unauthorized < Error
-    attr_reader :action, :subject
+    attr_reader :action, :subject, :attribute
     attr_writer :default_message
 
-    def initialize(message = nil, action = nil, subject = nil)
+    def initialize(message = nil, action = nil, subject = nil, attribute = nil)
       @message = message
       @action = action
       @subject = subject
+      @attribute = attribute
       @default_message = I18n.t(:"unauthorized.default", :default => "You are not authorized to access this page.")
     end
 

--- a/spec/cancan/exceptions_spec.rb
+++ b/spec/cancan/exceptions_spec.rb
@@ -3,12 +3,13 @@ require "spec_helper"
 describe CanCan::Unauthorized do
   describe "with action and subject" do
     before(:each) do
-      @exception = CanCan::Unauthorized.new(nil, :some_action, :some_subject)
+      @exception = CanCan::Unauthorized.new(nil, :some_action, :some_subject, :some_attribute)
     end
 
     it "has action and subject accessors" do
       @exception.action.should == :some_action
       @exception.subject.should == :some_subject
+      @exception.attribute.should == :some_attribute
     end
 
     it "has a changable default message" do
@@ -23,9 +24,10 @@ describe CanCan::Unauthorized do
       @exception = CanCan::Unauthorized.new("Access denied!")
     end
 
-    it "has nil action and subject" do
+    it "has nil action, subject and attribute" do
       @exception.action.should be_nil
       @exception.subject.should be_nil
+      @exception.attribute.should be_nil
     end
 
     it "has passed message" do


### PR DESCRIPTION
Including the offending attribute makes resolving authorization errors
much easier
