### PR TITLE
Use ActiveSupport.on_load to include CanCan::ControllerAdditions

### DIFF
--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -385,8 +385,8 @@ module CanCan
   end
 end
 
-if defined? ActionController::Base
-  ActionController::Base.class_eval do
+if defined? ActiveSupport
+  ActiveSupport.on_load :action_controller do
     include CanCan::ControllerAdditions
   end
 end


### PR DESCRIPTION
This way, rails-api users will not have to manually include CanCan::ControllerAdditions.

Regards.
