### PR TITLE
Fix: Unlike ActiveRecord, DataMapper doesn't raise record-not-found errors

### DIFF
--- a/lib/cancan/model_adapters/data_mapper_adapter.rb
+++ b/lib/cancan/model_adapters/data_mapper_adapter.rb
@@ -6,7 +6,7 @@ module CanCan
       end
 
       def self.find(model_class, id)
-        model_class.get(id)
+        model_class.get!(id)
       end
 
       def self.override_conditions_hash_matching?(subject, conditions)

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -68,6 +68,12 @@ if ENV["MODEL_ADAPTER"].nil? || ENV["MODEL_ADAPTER"] == "active_record"
       CanCan::ModelAdapters::ActiveRecordAdapter.find(Article, article.id).should == article
     end
 
+    it "should raise an error if record is not found" do
+      expect do
+        CanCan::ModelAdapters::ActiveRecordAdapter.find(Article, 123789)
+      end.to raise_error(::ActiveRecord::RecordNotFound)
+    end
+
     it "should not fetch any records when no abilities are defined" do
       Article.create!
       Article.accessible_by(@ability).should be_empty

--- a/spec/cancan/model_adapters/data_mapper_adapter_spec.rb
+++ b/spec/cancan/model_adapters/data_mapper_adapter_spec.rb
@@ -41,6 +41,12 @@ if ENV["MODEL_ADAPTER"] == "data_mapper"
       CanCan::ModelAdapters::DataMapperAdapter.find(Article, article.id).should == article
     end
 
+    it "should raise an error if record is not found" do
+      expect do
+        CanCan::ModelAdapters::DataMapperAdapter.find(Article, 123789)
+      end.to raise_error(::DataMapper::ObjectNotFoundError)
+    end
+
     it "should not fetch any records when no abilities are defined" do
       Article.create
       Article.accessible_by(@ability).should be_empty


### PR DESCRIPTION
This fix is to ensure that DataMapper adapter behavior matches ActiveRecord when a record is not found.  This allows to consistently handle missing records using `rescue_from`, rather than checking the resource variable for `nil`.
