### PR TITLE
added support for nested join conditions

### DIFF
--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -207,6 +207,16 @@ if ENV["MODEL_ADAPTER"].nil? || ENV["MODEL_ADAPTER"] == "active_record"
       @ability.model_adapter(Article, :read).conditions.should == "'t'='t'"
     end
 
+    it "should return appropriate sql conditions in complex case with nested joins" do
+      @ability.can :read, Comment, :article => { :category => { :visible => true } }
+      @ability.model_adapter(Comment, :read).conditions.should == { Category.table_name.to_sym => { :visible => true } }
+    end
+
+    it "should return appropriate sql conditions in complex case with nested joins of different depth" do
+      @ability.can :read, Comment, :article => { :published => true, :category => { :visible => true } }
+      @ability.model_adapter(Comment, :read).conditions.should == { Article.table_name.to_sym => { :published => true }, Category.table_name.to_sym => { :visible => true } }
+    end
+
     it "should not forget conditions when calling with SQL string" do
       @ability.can :read, Article, :published => true
       @ability.can :read, Article, ['secret=?', false]


### PR DESCRIPTION
There's a bug/feature incompleteness in the active_record_adapter, if you specify conditions via nested joins. E.g. if there's a comment model, that belongs_to a article, that belongs_to a category, you might to specify

```
can  :read, Comment, :article => { :category => { :condition => true } }
```

At the moment the neccessary joins are extracted correctly by `CanCan::ModelAdapters::ActiveRecordAdapter#joins`, i.e. `{ :article => :category }`. But the conditions hash for the where clause is still nested, i.e. it becomes `{ :articles => { :categories => { :condition => true } } }`. My patch does correct this to `{ :categories => { :condition => true } }`.
