### PR TITLE
load_collection? triggers sql query on inherited resources

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -74,7 +74,11 @@ module CanCan
     end
 
     def load_collection?
-      resource_base.respond_to?(:accessible_by) && !current_ability.has_block?(authorization_action, resource_class)
+      if @options[:through]
+        resource_base.proxy_association.klass
+      else
+        resource_base
+      end.respond_to?(:accessible_by) && !current_ability.has_block?(authorization_action, resource_class)
     end
 
     def load_collection


### PR DESCRIPTION
When `resource_base` is a `ActiveRecord::Associations::CollectionProxy` (common case - inherited resources)  `resource_base.respond_to?` will actually execute the query, due to it [being overwritten here](https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/associations/collection_proxy.rb#L71).

This presents a problem when working with big data sets + pagination, since all the records will be loaded in memory regardless of how the collection is paginated afterwards.

Rails version: 3.2.11
CanCan version: 1.6.8
