### PR TITLE
Explicitly return on load_resource if resource is already loaded

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -27,6 +27,7 @@ module CanCan
     end
 
     def load_resource
+      return if resource_instance_loaded?
       unless skip?(:load)
         if load_instance?
           self.resource_instance ||= load_resource_instance
@@ -158,6 +159,10 @@ module CanCan
 
     def resource_instance
       @controller.instance_variable_get("@#{instance_name}") if load_instance?
+    end
+
+    def resource_instance_loaded?
+      !@controller.instance_variable_get("@#{instance_name}").nil?
     end
 
     def collection_instance=(instance)


### PR DESCRIPTION
Hi Ryan,

I've been experiencing some problems using `:through`. Let's say I have a ressource `Thread`, which belongs to `Forum`. In `ThreadsController` I could then have

```
load_and_authorize_resource :through => :forum
```

It seems that the the `:through` will not respect an already loaded instance variable. If I have

```
before_filter :manually_set_thread # Which initailizes @thread
load_and_authorize_resource :through => :forum
```

the `load_resource`-part will run into problems, because of this part `!current_ability.has_block?(authorization_action, resource_class)`.

Wouldn't it work if `load_resource` simply does nothing if  `@thread` is already present?
