### PR TITLE
support for active hash model adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ when "data_mapper"
 when "mongoid"
   gem "bson_ext", "~> 1.1"
   gem "mongoid", "~> 2.0.0.beta.20"
+when "active_hash"
+  gem "active_hash", "~> 0.9"
 else
   raise "Unknown model adapter: #{ENV["MODEL_ADAPTER"]}"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ end
 
 desc "Run specs for all adapters"
 task :spec_all do
-  %w[active_record data_mapper mongoid].each do |model_adapter|
+  %w[active_record data_mapper mongoid active_hash].each do |model_adapter|
     puts "MODEL_ADAPTER = #{model_adapter}"
     system "rake spec MODEL_ADAPTER=#{model_adapter}"
   end

--- a/lib/cancan.rb
+++ b/lib/cancan.rb
@@ -11,3 +11,4 @@ require 'cancan/model_adapters/default_adapter'
 require 'cancan/model_adapters/active_record_adapter' if defined? ActiveRecord
 require 'cancan/model_adapters/data_mapper_adapter' if defined? DataMapper
 require 'cancan/model_adapters/mongoid_adapter' if defined?(Mongoid) && defined?(Mongoid::Document)
+require 'cancan/model_adapters/active_hash_adapter' if defined?(ActiveHash)

--- a/lib/cancan/model_adapters/active_hash_adapter.rb
+++ b/lib/cancan/model_adapters/active_hash_adapter.rb
@@ -1,0 +1,32 @@
+module CanCan
+  module ModelAdapters
+    class ActiveHashAdapter < AbstractAdapter
+      def self.for_class?(model_class)
+        model_class <= ActiveHash::Base
+      end
+
+      def database_records
+        records = []
+        return records if @rules.size.zero?
+
+        all = @model_class.all
+        cans, cannots = @rules.partition { |r| r.base_behavior }
+        return all if cans.empty?
+
+        cans.each do |rule|
+          records |= @model_class.where(rule.conditions)
+        end
+
+        cannots.each do |rule|
+          records -= @model_class.where(rule.conditions)
+        end
+
+        records
+      end
+    end
+  end
+end
+
+ActiveHash::Base.class_eval do
+  include CanCan::ModelAdditions
+end

--- a/spec/cancan/model_adapters/active_hash_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_hash_adapter_spec.rb
@@ -1,0 +1,80 @@
+if ENV["MODEL_ADAPTER"] == "active_hash"
+  require "spec_helper"
+
+  # override some methods here to help cleanup and id generation
+  class ModelBase < ActiveHash::Base
+    @@id = 0
+
+    # remove existing records and reset our index
+    def self.reset!
+      self.data = []
+      @@id = 0
+    end
+
+    # @override to auto increment the ID
+    def create(attributes = {})
+      super(attributes.merge(:id => (@@id += 1)))
+    end
+  end
+
+  class Article < ModelBase
+    fields :published, :secret
+  end
+
+  describe CanCan::ModelAdapters::ActiveHashAdapter do
+    before(:each) do
+      Article.reset!
+      @ability = Object.new
+      @ability.extend(CanCan::Ability)
+    end
+
+    it "should be for only active hash classes" do
+      CanCan::ModelAdapters::ActiveHashAdapter.should_not be_for_class(Object)
+      CanCan::ModelAdapters::ActiveHashAdapter.should be_for_class(Article)
+      CanCan::ModelAdapters::AbstractAdapter.adapter_class(Article).should == CanCan::ModelAdapters::ActiveHashAdapter
+    end
+
+    it "should find record" do
+      article = Article.create
+      CanCan::ModelAdapters::ActiveHashAdapter.find(Article, 1).should == article
+    end
+
+    it "should not fetch any records when no abilities are defined" do
+      article = Article.create
+      Article.accessible_by(@ability).should be_empty
+    end
+
+    it "should fetch all articles when one can read all" do
+      @ability.can :read, Article
+      article = Article.create
+      Article.accessible_by(@ability).should == [article]
+    end
+
+    it "should fetch only the articles that are published" do
+      @ability.can :read, Article, :published => true
+      article1 = Article.create(:published => true)
+      article2 = Article.create(:published => false)
+      Article.accessible_by(@ability).should == [article1]
+    end
+
+    it "should fetch any articles which are published or secret" do
+      @ability.can :read, Article, :published => true
+      @ability.can :read, Article, :secret => true
+      article1 = Article.create(:published => true, :secret => false)
+      article2 = Article.create(:published => true, :secret => true)
+      article3 = Article.create(:published => false, :secret => true)
+      article4 = Article.create(:published => false, :secret => false)
+      Article.accessible_by(@ability).should =~ [article1, article2, article3]
+    end
+
+    it "should fetch only the articles that are published and not secret" do
+      @ability.can :read, Article, :published => true
+      @ability.cannot :read, Article, :secret => true
+      article1 = Article.create(:published => true, :secret => false)
+      article2 = Article.create(:published => true, :secret => true)
+      article3 = Article.create(:published => false, :secret => true)
+      article4 = Article.create(:published => false, :secret => false)
+      Article.accessible_by(@ability).should == [article1]
+    end
+  end
+end


### PR DESCRIPTION
Not sure if this is outside the scope of cancan, but I had a need in my current project for stubbing out resources using active hash (ActiveYaml more specifically) before they could be backed by a proper DB and noticed there was a lack of support. This PR allows you to treat active hash objects like regular model classes in the controller and allows for:

```ruby
# model
class Mock::Stadium < ActiveYaml::Base
  set_filename 'stadiums'
  fields :name, :city, :state
end

# controller
class Api::V1::StadiumsController < Api::V1::BaseController
  load_and_authorize_resource class: Mock::Stadium
end
``` 

Currently it only supports basic scoping and no associations.