### PR TITLE
fix #845: 'cannot' rules using meta_where expressions are not inverted

### DIFF
--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -104,7 +104,8 @@ module CanCan
           if mergeable_conditions
             @model_class.where(conditions).joins(joins)
           else
-            @model_class.where(*(@rules.map(&:conditions))).joins(joins)
+            adapt = ->(r) {@model_class.where(r.conditions).arel.wheres.map {|wv| r.base_behavior ? wv : wv.not} }
+            @model_class.where(*(@rules.map(&adapt).flatten)).joins(joins)
           end
         else
           @model_class.scoped(:conditions => conditions, :joins => joins)

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -282,6 +282,16 @@ if ENV["MODEL_ADAPTER"].nil? || ENV["MODEL_ADAPTER"] == "active_record"
       @ability.should_not be_able_to(:read, article2)
     end
 
+    it "should invert merged negative MetaWhere and non-MetaWhere cannot rules" do
+      @ability.can :read, Article, :priority => [1,3]
+      @ability.cannot :read, Article, :priority.lt => 2
+      article1 = Article.create!(:priority => 1)
+      article2 = Article.create!(:priority => 3)
+      Article.accessible_by(@ability).should == [article2]
+      @ability.should_not be_able_to(:read, article1)
+      @ability.should be_able_to(:read, article2)
+    end
+
     it "should match any MetaWhere condition" do
       adapter = CanCan::ModelAdapters::ActiveRecordAdapter
       article1 = Article.new(:priority => 1, :name => "Hello World")


### PR DESCRIPTION
When having meta_where conditions, the resulting sql doesn't have the conditions inverted. 
In case of merges with straight hashes, the sql resulting from these straight hashes isn't inverted either.
