### PR TITLE
added params check call for strong parameters

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -240,7 +240,7 @@ module CanCan
       if @controller.respond_to?(param_method_name, true)
         @controller.send(param_method_name)
       elsif @controller.respond_to?(:permitted_params, true)
-        @controller.send(:permitted_params)
+        @controller.send(:permitted_params)[resource_key]
       else
         @params[resource_key]
       end


### PR DESCRIPTION
Added a call in `resource_params` to a controller method called `#{resource_key}_params` for retrieving whitelisted parameters. So for example in a users controller CanCan would retrieve the users parameter via the whitelisting method `user_params`, if defined.

I probably haven't considered all cases here. So this might be just a starting point for getting CanCan working with Rails 4. It works well in first tests I made.

What do you think? 
