### PR TITLE
add model adapter for sequel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ when "data_mapper"
 when "mongoid"
   gem "bson_ext", "~> 1.1"
   gem "mongoid", "~> 2.0.0.beta.20"
+when "sequel"
+  gem "sqlite3"
+  gem "sequel", "~> 3.47.0"
 else
   raise "Unknown model adapter: #{ENV["MODEL_ADAPTER"]}"
 end

--- a/lib/cancan.rb
+++ b/lib/cancan.rb
@@ -11,3 +11,4 @@ require 'cancan/model_adapters/default_adapter'
 require 'cancan/model_adapters/active_record_adapter' if defined? ActiveRecord
 require 'cancan/model_adapters/data_mapper_adapter' if defined? DataMapper
 require 'cancan/model_adapters/mongoid_adapter' if defined?(Mongoid) && defined?(Mongoid::Document)
+require 'cancan/model_adapters/sequel_adapter' if defined? Sequel

--- a/lib/cancan/model_adapters/sequel_adapter.rb
+++ b/lib/cancan/model_adapters/sequel_adapter.rb
@@ -1,0 +1,87 @@
+module CanCan
+  module ModelAdapters
+    class SequelAdapter < AbstractAdapter
+      def self.for_class?(model_class)
+        model_class <= Sequel::Model
+      end
+
+      def self.find(model_class, id)
+        model_class[id]
+      end
+
+      def self.override_condition_matching?(subject, name, value)
+        value.kind_of?(Hash)
+      end
+
+      def self.matches_condition?(subject, name, value)
+        obj = subject.send(name)
+        if obj.nil?
+          false
+        else
+          value.each do |k, v|
+            if v.kind_of?(Hash)
+              return false unless self.matches_condition?(obj, k, v)
+            elsif obj.send(k) != v
+              return false
+            end
+          end
+        end
+      end
+
+      def database_records
+        if @rules.size == 0
+          @model_class.where('1=0')
+        else
+          # only need to process can rules if there are no can rule with empty conditions
+          rules = @rules.reject { |rule| rule.base_behavior && rule.conditions.empty? }
+          rules.reject! { |rule| rule.base_behavior } if rules.count < @rules.count
+
+          can_condition_added = false
+          rules.reverse.inject(@model_class.dataset) do |records, rule|
+            normalized_conditions = normalize_conditions(rule.conditions)
+            if rule.base_behavior
+              if can_condition_added
+                records.or normalized_conditions
+              else
+                can_condition_added = true
+                records.where normalized_conditions
+              end
+            else
+              records.exclude normalized_conditions
+            end
+          end
+        end
+      end
+
+      private
+
+      def normalize_conditions(conditions, model_class = @model_class)
+        return conditions unless conditions.kind_of? Hash
+        conditions.inject({}) do |result_hash, (name, value)|
+          if value.kind_of? Hash
+            value = value.dup
+            association_class = model_class.association_reflection(name)[:cache][:class]
+            nested = value.inject({}) do |nested, (k, v)|
+              if v.kind_of?(Hash)
+                value.delete(k)
+                nested_class = association_class.association_reflection(k)[:cache][:class]
+                nested[k] = nested_class.where(normalize_conditions(v, association_class))
+              else
+                nested[k] = v
+              end
+              nested
+            end
+            result_hash[name] = association_class.where(nested)
+          else
+            result_hash[name] = value
+          end
+          result_hash
+        end
+      end
+    end
+  end
+end
+
+Sequel::Model.class_eval do
+  include CanCan::ModelAdditions
+end

--- a/lib/cancan/model_adapters/sequel_adapter.rb
+++ b/lib/cancan/model_adapters/sequel_adapter.rb
@@ -60,11 +60,11 @@ module CanCan
         conditions.inject({}) do |result_hash, (name, value)|
           if value.kind_of? Hash
             value = value.dup
-            association_class = model_class.association_reflection(name)[:cache][:class]
+            association_class = model_class.association_reflection(name).associated_class
             nested = value.inject({}) do |nested, (k, v)|
               if v.kind_of?(Hash)
                 value.delete(k)
-                nested_class = association_class.association_reflection(k)[:cache][:class]
+                nested_class = association_class.association_reflection(k).associated_class
                 nested[k] = nested_class.where(normalize_conditions(v, association_class))
               else
                 nested[k] = v

--- a/spec/cancan/model_adapters/sequel_adapter_spec.rb
+++ b/spec/cancan/model_adapters/sequel_adapter_spec.rb
@@ -1,0 +1,148 @@
+if ENV["MODEL_ADAPTER"] == "sequel"
+  require "spec_helper"
+
+  DB = Sequel.sqlite
+
+  DB.create_table :users do
+    primary_key :id
+    String :name
+  end
+
+  class User < Sequel::Model
+    one_to_many :articles
+  end
+
+  DB.create_table :articles do
+    primary_key :id
+    String :name
+    TrueClass :published
+    TrueClass :secret
+    Integer :priority
+    foreign_key :user_id, :users
+  end
+
+  class Article < Sequel::Model
+    many_to_one :user
+    one_to_many :comments
+  end
+
+  DB.create_table :comments do
+    primary_key :id
+    TrueClass :spam
+    foreign_key :article_id, :articles
+  end
+
+  class Comment < Sequel::Model
+    many_to_one :article
+  end
+
+  describe CanCan::ModelAdapters::SequelAdapter do
+    before(:each) do
+      Comment.dataset.delete
+      Article.dataset.delete
+      User.dataset.delete
+      @ability = Object.new
+      @ability.extend(CanCan::Ability)
+    end
+
+    it "should be for only sequel model classes" do
+      CanCan::ModelAdapters::SequelAdapter.should_not be_for_class(Object)
+      CanCan::ModelAdapters::SequelAdapter.should be_for_class(Article)
+      CanCan::ModelAdapters::AbstractAdapter.adapter_class(Article).should == CanCan::ModelAdapters::SequelAdapter
+    end
+
+    it "should find record" do
+      article = Article.create
+      CanCan::ModelAdapters::SequelAdapter.find(Article, article.id).should == article
+    end
+
+    it "should not fetch any records when no abilities are defined" do
+      Article.create
+      Article.accessible_by(@ability).all.should be_empty
+    end
+
+    it "should fetch all articles when one can read all" do
+      @ability.can :read, Article
+      article = Article.create
+      @ability.should be_able_to(:read, article)
+      Article.accessible_by(@ability).all.should == [article]
+    end
+
+    it "should fetch only the articles that are published" do
+      @ability.can :read, Article, :published => true
+      article1 = Article.create(:published => true)
+      article2 = Article.create(:published => false)
+      @ability.should be_able_to(:read, article1)
+      @ability.should_not be_able_to(:read, article2)
+      Article.accessible_by(@ability).all.should == [article1]
+    end
+
+    it "should fetch any articles which are published or secret" do
+      @ability.can :read, Article, :published => true
+      @ability.can :read, Article, :secret => true
+      article1 = Article.create(:published => true, :secret => false)
+      article2 = Article.create(:published => true, :secret => true)
+      article3 = Article.create(:published => false, :secret => true)
+      article4 = Article.create(:published => false, :secret => false)
+      @ability.should be_able_to(:read, article1)
+      @ability.should be_able_to(:read, article2)
+      @ability.should be_able_to(:read, article3)
+      @ability.should_not be_able_to(:read, article4)
+      Article.accessible_by(@ability).all.should == [article1, article2, article3]
+    end
+
+    it "should fetch only the articles that are published and not secret" do
+      @ability.can :read, Article, :published => true
+      @ability.cannot :read, Article, :secret => true
+      article1 = Article.create(:published => true, :secret => false)
+      article2 = Article.create(:published => true, :secret => true)
+      article3 = Article.create(:published => false, :secret => true)
+      article4 = Article.create(:published => false, :secret => false)
+      @ability.should be_able_to(:read, article1)
+      @ability.should_not be_able_to(:read, article2)
+      @ability.should_not be_able_to(:read, article3)
+      @ability.should_not be_able_to(:read, article4)
+      Article.accessible_by(@ability).all.should == [article1]
+    end
+
+    it "should only read comments for articles which are published" do
+      @ability.can :read, Comment, :article => { :published => true }
+      comment1 = Comment.create(:article => Article.create(:published => true))
+      comment2 = Comment.create(:article => Article.create(:published => false))
+      @ability.should be_able_to(:read, comment1)
+      @ability.should_not be_able_to(:read, comment2)
+      Comment.accessible_by(@ability).all.should == [comment1]
+    end
+
+    it "should only read comments for articles which are published and user is 'me'" do
+      @ability.can :read, Comment, :article => { :user => { :name => 'me' }, :published => true }
+      user1 = User.create(:name => 'me')
+      comment1 = Comment.create(:article => Article.create(:published => true, :user => user1))
+      comment2 = Comment.create(:article => Article.create(:published => true))
+      comment3 = Comment.create(:article => Article.create(:published => false, :user => user1))
+      @ability.should be_able_to(:read, comment1)
+      @ability.should_not be_able_to(:read, comment2)
+      @ability.should_not be_able_to(:read, comment3)
+      Comment.accessible_by(@ability).all.should == [comment1]
+    end
+
+    it "should allow conditions in SQL and merge with hash conditions" do
+      @ability.can :read, Article, :published => true
+      @ability.can :read, Article, ["secret=?", true] do |article|
+        article.secret
+      end
+      @ability.cannot :read, Article, "priority > 1" do |article|
+        article.priority > 1
+      end
+      article1 = Article.create(:published => true, :secret => false, :priority => 1)
+      article2 = Article.create(:published => true, :secret => true, :priority => 1)
+      article3 = Article.create(:published => true, :secret => true, :priority => 2)
+      article4 = Article.create(:published => false, :secret => false, :priority => 2)
+      @ability.should be_able_to(:read, article1)
+      @ability.should be_able_to(:read, article2)
+      @ability.should_not be_able_to(:read, article3)
+      @ability.should_not be_able_to(:read, article4)
+      Article.accessible_by(@ability).all.should == [article1, article2]
+    end
+  end
+end


### PR DESCRIPTION
We build this model adapter in order to add authorization capability to our API server, which is using sequel as ORM.
