### PR TITLE
Isue #835 - CanCan ActiveModel::ForbiddenAttributesError with rails 4

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -230,6 +230,8 @@ module CanCan
         rescue
           nil
         end
+      else
+        @params[extract_key(namespaced_name)]
       end
     end
 

--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -12,6 +12,7 @@ module CanCan
     end
 
     def initialize(controller, *args)
+      @params_method = args.last[:attributes] if args.last.respond_to?(:[])
       @controller = controller
       @params = controller.params
       @options = args.extract_options!
@@ -223,7 +224,13 @@ module CanCan
     end
 
     def resource_params_by_namespaced_name
-      @params[extract_key(namespaced_name)]
+      if @params_method
+        begin
+          @controller.send(@params_method.to_sym)
+        rescue
+          nil
+        end
+      end
     end
 
     def namespace

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -488,4 +488,14 @@ describe CanCan::ControllerResource do
     lambda { resource.load_and_authorize_resource }.should_not raise_error
     @controller.instance_variable_get(:@project).should be_nil
   end
+
+  context "given load_and_authorize_resource has an attributes method name" do
+    it "should use attributes method to acquire resource params" do
+      @params.merge!(:controller => "project", :action => "create")
+      sanitized = {:first => 1, :second => 2}
+      stub(@controller).attributes_method {sanitized}
+      resource = CanCan::ControllerResource.new(@controller, {:attributes => :attributes_method})
+      resource.send("resource_params_by_namespaced_name").should eq(sanitized)
+    end
+  end
 end


### PR DESCRIPTION
I recently ran into the issue of getting the ForbiddenAttribuesError when using CanCan on a Rails 4 app that I am building.  After looking into the issue it appears that the problem is that when load_and_authorize_resource is used in a controller it loads up the resource using the params straight from the controller before they have been sanitized.

My approach was to add the ability to specify the params method defined in the controller as an argument to load_and_authorize_resource. E.g load_and_authorize_resource attributes: :my_method.  This method is then used to grab the params to build the resource from instead of using the params straight from the controller.

I have also included a check for the params method being specified which seems to preserve backward compatibility.
