### PR TITLE
treat ActiveRecord::Relation as Array

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -216,14 +216,24 @@ module CanCan
     def resource_params
       if @options[:class]
         params_key = extract_key(@options[:class])
-        return @params[params_key] if @params[params_key]
+        if params = fetch_params(params_key)
+          return params
+        end
       end
 
       resource_params_by_namespaced_name
     end
 
     def resource_params_by_namespaced_name
-      @params[extract_key(namespaced_name)]
+      fetch_params extract_key(namespaced_name)
+    end
+
+    def fetch_params(key)
+      @controller.respond_to?(params_method(key), true) ? @controller.send(params_method(key)) : @params[key]
+    end
+
+    def params_method(key)
+      "#{key}_params".to_sym
     end
 
     def namespace

--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -4,11 +4,11 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
     ability.can?(*args)
   end
 
-  failure_message_for_should do |ability|
+  failure_message do |ability|
     "expected to be able to #{args.map(&:inspect).join(" ")}"
   end
 
-  failure_message_for_should_not do |ability|
+  failure_message_when_negated do |ability|
     "expected not to be able to #{args.map(&:inspect).join(" ")}"
   end
 end

--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -111,7 +111,7 @@ module CanCan
             else
               attribute = subject.send(name)
               if value.kind_of?(Hash)
-                if attribute.kind_of? Array
+                if attribute.kind_of?(Array) || attribute.kind_of?(ActiveRecord::Relation)
                   attribute.any? { |element| matches_conditions_hash? element, value }
                 else
                   !attribute.nil? && matches_conditions_hash?(attribute, value)


### PR DESCRIPTION
This fixes the problem with Rails 4, where ActiveRecord::Relation is no longer recognized as Array, which gives problems when defining abilities with joins - see https://github.com/ryanb/cancan/issues/916
