### PR TITLE
Clear up inconsistency in authorize_resource examples

### DIFF
--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -139,10 +139,10 @@ module CanCan
       #
       #   class BooksController < ApplicationController
       #     authorize_resource :author
-      #     authorize_resource :book
+      #     authorize_resource :show
       #   end
       #
-      # Here it will authorize :+show+, @+author+ on every action before authorizing the book.
+      # Here it will authorize @+author+, @+show+ on every action before authorizing the book.
       #
       # That first argument is optional and will default to the singular name of the controller.
       # A hash of options (see below) can also be passed to this method to further customize it.


### PR DESCRIPTION
## Forward

While reading through the source code and its examples, I noticed what I believe is an inconsistency in the example code and example explanation for `authorize_resource`.

I created two comments on the related lines in the commit where this was introduced. The comments are asking whether my hunch is correct.

https://github.com/ryanb/cancan/commit/25a1c553bfefafd3002bddfc67152a27bd0eb3d7#L2R115
https://github.com/ryanb/cancan/commit/25a1c553bfefafd3002bddfc67152a27bd0eb3d7#L2R118

This pull request is created in case my hunch proves correct, and the documentation needs to be updated to reflect that.
## Change Description

Changed the explanation of the code in the example to have the same references and order as the related example code.

Previously, the example code referenced a `book`, whereas the explanation of that example code mentioned a `show`. The example and the explanation did not match.
