### PR TITLE
Don't load parent without id_param.

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -127,11 +127,13 @@ module CanCan
     end
 
     def id_param
-      if @options[:id_param]
+      value = if @options[:id_param]
         @params[@options[:id_param]]
       else
         @params[parent? ? :"#{name}_id" : :id]
-      end.to_s
+      end
+
+      value && value.to_s
     end
 
     def member_action?

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -247,6 +247,14 @@ describe CanCan::ControllerResource do
     @controller.instance_variable_get(:@project).should == project
   end
 
+  it "should not load parent resource if the id param isn't given" do
+    project = Project.create!
+    @params.merge!(:controller => "categories", :action => "index")
+    resource = CanCan::ControllerResource.new(@controller, :project)
+    resource.load_resource
+    @controller.instance_variable_get(:@project).should be_nil
+  end
+
   it "should load resource through the association of another parent resource using instance variable" do
     @params.merge!(:action => "show", :id => "123")
     category = Object.new


### PR DESCRIPTION
This appears to have been the intention. If so, it regressed in d5123e0eb3017de67a9e6afa45c14a5ef096f2a8.

Without this, I'm not sure how shallow routes can work, so I'm assuming this was a bug.
