### PR TITLE
FIX: Variable collision prevents defining permissions with multiple nested conditons. closes #965

### DIFF
--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -73,8 +73,7 @@ module CanCan
                 value.delete(k)
                 nested[k] = v
               else
-                name = model_class.reflect_on_association(name).table_name.to_sym
-                result_hash[name] = value
+                result_hash[model_class.reflect_on_association(name).table_name.to_sym] = value
               end
               nested
             end


### PR DESCRIPTION
Example

``` ruby
can :read, Comment, post: {private: false, author_id: author.id}
```

Raises `NoMethodError: undefined method table_name for nil:NilClass`
