### PR TITLE
Do Not Execute Scope When Checking Class Rule

### DIFF
--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -38,7 +38,7 @@ module CanCan
         matches_conditions_hash?(subject)
       else
         # Don't stop at "cannot" definitions when there are conditions.
-        @conditions.empty? ? true : @base_behavior
+        conditions_empty? ? true : @base_behavior
       end
     end
 

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -316,5 +316,17 @@ if ENV["MODEL_ADAPTER"].nil? || ENV["MODEL_ADAPTER"] == "active_record"
       # adapter.matches_condition?(article1, :name.nlike, "%helo%").should be_true
       # adapter.matches_condition?(article1, :name.nlike, "%ello worl%").should be_false
     end
+
+    it 'should not execute a scope when checking ability on the class' do
+      relation = Article.where(:secret => true)
+      @ability.can :read, Article, relation do |article|
+        article.secret == true
+      end
+
+      # Ensure the ActiveRecord::Relation condition does not trigger a count query
+      stub(relation).count { fail 'Unexpected scope execution.' }
+
+      expect { @ability.can? :read, Article }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
I expect that a class level access `can?` check will not trigger a scope defined on the ability. The current code executes a count against the scope and drives logic based on the result. This pull patches the presumably inadvertent scope execution. If that scope execution is the expected behavior then this pull should be rejected and the docs should be clarified to make this behavior explicit.

For example, I expect the following will **not** trigger `Foo.some_scoped_query`:

``` ruby
# Ability.rb
can :read, Foo, Foo.some_scoped_query do |foo|
  foo.some_instance_check
end

# In some controller
can?(:read, Foo)
```

In the current code CanCan checks the conditions on a rule to see if they are empty. `@conditions.empty?` calls `ActiveRecord::Relation#empty?` when a scoped condition is provided. `ActiveRecord::Relation#empty?` will execute the scoped query as a count to see if any records are returned.
