### PR TITLE
Avoid unnecessary sql execution

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -178,7 +178,7 @@ module CanCan
       if @options[:through]
         if parent_resource
           base = @options[:singleton] ? resource_class : parent_resource.send(@options[:through_association] || name.to_s.pluralize)
-          base = base.scoped if defined?(ActiveRecord) && ActiveRecord::VERSION::MAJOR == 3
+          base = base.scoped if base.respond_to?(:scoped) && defined?(ActiveRecord) && ActiveRecord::VERSION::MAJOR == 3
           base
         elsif @options[:shallow]
           resource_class


### PR DESCRIPTION
Hi,

When I'm using the `:through` option, in a `load_and_authorize_resource`, with ActiveRecord 3, I can see unexpected SQL queries in my log tail.

```
load_and_authorize_resource :ufo, through: :mothership
```

It seems to come from [`resource_base.respond_to?(:accessible_by)`](https://github.com/ryanb/cancan/blob/master/lib/cancan/controller_resource.rb#L77).

You can try in a rails console :
    mothership.ufos.respond_to?(:accessible_by)
    => # fire the SQL query and load all ufos 

```
mothership.ufos.scoped.respond_to?(:accessible_by)
=> # wont fire anything
```

However, it works well with AR 4.
