### PR TITLE
Changing [].flatten to array wrapper method

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -245,11 +245,11 @@ module CanCan
     end
 
     def collection_actions
-      [:index] + [@options[:collection]].flatten
+      [:index] + Array(@options[:collection])
     end
 
     def new_actions
-      [:new, :create] + [@options[:new]].flatten
+      [:new, :create] + Array(@options[:new])
     end
 
     private


### PR DESCRIPTION
Changing [].flatten to array wrapper method

```
   [[1,2,3]].flatten <=> Array([1,2,3])   =>  [1,2,3]
   [1].flatten    <=>   Array(1)    => [1]
```

And this will avoid the nil value

```
   [nil].flatten   => [nil]
   Array(nil)    =>  []
```
