### PR TITLE
Rspec 3 syntax

### DIFF
--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -8,7 +8,7 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
     "expected to be able to #{args.map(&:inspect).join(" ")}"
   end
 
-  failure_message_for_should_not do |ability|
+  failure_message_when_negated do |ability|
     "expected not to be able to #{args.map(&:inspect).join(" ")}"
   end
 end

--- a/spec/matchers.rb
+++ b/spec/matchers.rb
@@ -3,11 +3,11 @@ RSpec::Matchers.define :orderlessly_match do |original_string|
     original_string.split('').sort == given_string.split('').sort
   end
 
-  failure_message_for_should do |given_string|
+  failure_message do |given_string|
     "expected \"#{given_string}\" to have the same characters as \"#{original_string}\""
   end
 
-  failure_message_for_should_not do |given_string|
+  failure_message_when_negated do |given_string|
     "expected \"#{given_string}\" not to have the same characters as \"#{original_string}\""
   end
 end


### PR DESCRIPTION
This uses the new rspec 3 syntax so you can avoid those lovely deprecation warnings.
