### PR TITLE
RSpec `failure_message_for_should_not` is deprecated

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use 1.9.3-p551@cancan --create
+rvm use 1.8.7@cancan --create

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use 1.8.7@cancan --create
+rvm use 1.9.3-p551@cancan --create

--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -1,10 +1,10 @@
-rspec_module = Kernel.const_get(defined?(RSpec::Core) ? 'RSpec' : 'Spec')  # for RSpec 1 compatability
-rspec_module::Matchers.define :be_able_to do |*args|
+rspec_module = defined?(RSpec::Core) ? 'RSpec' : 'Spec' # for RSpec 1 compatability
+Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
   match do |ability|
     ability.can?(*args)
   end
 
-  if rspec_module::Version && rspec_module::Version::STRING =~ /^3\./
+  if respond_to?(:failure_message) && respond_to?(:failure_message_when_negated)
     failure_message do |ability|
        "expected to be able to #{args.map(&:inspect).join(" ")}"
     end

--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -1,14 +1,24 @@
-rspec_module = defined?(RSpec::Core) ? 'RSpec' : 'Spec'  # for RSpec 1 compatability
-Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
+rspec_module = Kernel.const_get(defined?(RSpec::Core) ? 'RSpec' : 'Spec')  # for RSpec 1 compatability
+rspec_module::Matchers.define :be_able_to do |*args|
   match do |ability|
     ability.can?(*args)
   end
 
-  failure_message_for_should do |ability|
-    "expected to be able to #{args.map(&:inspect).join(" ")}"
-  end
+  if rspec_module::Version && rspec_module::Version::STRING =~ /^3\./
+    failure_message do |ability|
+       "expected to be able to #{args.map(&:inspect).join(" ")}"
+    end
 
-  failure_message_for_should_not do |ability|
-    "expected not to be able to #{args.map(&:inspect).join(" ")}"
+    failure_message_when_negated do |ability|
+      "expected not to be able to #{args.map(&:inspect).join(" ")}"
+    end
+  else
+    failure_message_for_should do |ability|
+      "expected to be able to #{args.map(&:inspect).join(" ")}"
+    end
+
+    failure_message_for_should_not do |ability|
+      "expected not to be able to #{args.map(&:inspect).join(" ")}"
+    end
   end
 end


### PR DESCRIPTION
Fixed #997
