### PR TITLE
Raise CanCan::AccessDenied when current_user is not found

### DIFF
--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -334,6 +334,7 @@ module CanCan
     # See the load_and_authorize_resource method to automatically add the authorize! behavior
     # to the default RESTful actions.
     def authorize!(*args)
+      raise CanCan::AccessDenied.new("User not found") if current_user.nil?
       @_authorized = true
       current_ability.authorize!(*args)
     end


### PR DESCRIPTION
Currently fails with an ArgumentError in my application code.
And I thought the perfect fix was here.
Any opinion on making this change?
